### PR TITLE
feat(overlay): generic targets, export defaults, scoped opts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21110,6 +21110,18 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
@@ -23278,7 +23290,23 @@
         "@speclynx/apidom-error": "4.6.0",
         "@speclynx/apidom-json-path": "4.6.0",
         "@speclynx/apidom-ns-overlay-1": "4.6.0",
-        "@speclynx/apidom-reference": "4.6.0"
+        "@speclynx/apidom-reference": "4.6.0",
+        "type-fest": "^5.5.0"
+      }
+    },
+    "packages/apidom-overlay/node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/apidom-parser": {

--- a/packages/apidom-overlay/package.json
+++ b/packages/apidom-overlay/package.json
@@ -58,7 +58,8 @@
     "@speclynx/apidom-error": "4.6.0",
     "@speclynx/apidom-json-path": "4.6.0",
     "@speclynx/apidom-ns-overlay-1": "4.6.0",
-    "@speclynx/apidom-reference": "4.6.0"
+    "@speclynx/apidom-reference": "4.6.0",
+    "type-fest": "^5.5.0"
   },
   "files": [
     "src/**/*.mjs",

--- a/packages/apidom-overlay/src/apply/realms/apidom.ts
+++ b/packages/apidom-overlay/src/apply/realms/apidom.ts
@@ -367,10 +367,10 @@ export const applyOverlay = <T extends Element | ParseResultElement>(
 
   let target: Element;
   if (targetElement instanceof ParseResultElement) {
-    if (targetElement.api === undefined) {
-      throw new OverlayError('Target ParseResultElement contains no API element');
+    if (targetElement.result === undefined) {
+      throw new OverlayError('Target ParseResultElement contains no result element');
     }
-    target = targetElement.api;
+    target = targetElement.result;
   } else {
     target = targetElement;
   }
@@ -387,7 +387,9 @@ export const applyOverlay = <T extends Element | ParseResultElement>(
   }
 
   if (targetElement instanceof ParseResultElement) {
-    targetElement.replaceResult(target);
+    if (target !== targetElement.result) {
+      targetElement.replaceResult(target);
+    }
     return targetElement;
   }
 

--- a/packages/apidom-overlay/src/apply/realms/uri.ts
+++ b/packages/apidom-overlay/src/apply/realms/uri.ts
@@ -5,6 +5,7 @@ import {
   mergeOptions,
   type ApiDOMReferenceOptions as ReferenceOptions,
 } from '@speclynx/apidom-reference';
+import type { PartialDeep } from 'type-fest';
 
 import { applyOverlay as applyOverlayApiDOM, type ApplyOptions } from './apidom.ts';
 import OverlayError from '../../errors/OverlayError.ts';
@@ -12,9 +13,11 @@ import OverlayError from '../../errors/OverlayError.ts';
 /**
  * @public
  */
-export interface ApplyOverlayOptions extends Partial<ReferenceOptions>, ApplyOptions {}
+export interface ApplyOverlayOptions extends ApplyOptions {
+  readonly reference?: PartialDeep<ReferenceOptions>;
+}
 
-const defaultOptions = {
+const defaultReferenceOptions = {
   parse: {
     parserOpts: {
       strict: false,
@@ -39,6 +42,15 @@ const defaultOptions = {
 };
 
 /**
+ * @public
+ */
+export const defaultOptions: ApplyOverlayOptions = {
+  immutable: false,
+  strict: false,
+  reference: defaultReferenceOptions,
+};
+
+/**
  * Applies an overlay document from a file/URL to its target document.
  *
  * Parses the overlay, resolves the target from `targetURI` or the overlay's
@@ -55,12 +67,15 @@ const defaultOptions = {
 const applyOverlay = async (
   overlayURI: string,
   targetURI?: string,
-  options: ApplyOverlayOptions = { immutable: false, strict: false },
+  options: ApplyOverlayOptions = defaultOptions,
 ): Promise<ParseResultElement> => {
-  const mergedOptions = mergeOptions(defaultOptions as unknown as ReferenceOptions, options);
+  const mergedRefOptions = mergeOptions(
+    defaultReferenceOptions as unknown as ReferenceOptions,
+    (options.reference ?? defaultReferenceOptions) as ReferenceOptions,
+  );
 
   // parse the overlay document along with document attached to `extends` field (if present)
-  const overlayParseResult = await parse(overlayURI, mergedOptions);
+  const overlayParseResult = await parse(overlayURI, mergedRefOptions);
   const overlayElement = overlayParseResult.api;
 
   if (!isOverlay1Element(overlayElement)) {
@@ -69,8 +84,7 @@ const applyOverlay = async (
 
   let targetParseResult;
   if (targetURI) {
-    const targetOptions = mergeOptions(defaultOptions as unknown as ReferenceOptions, options);
-    targetParseResult = await parse(targetURI, targetOptions);
+    targetParseResult = await parse(targetURI, mergedRefOptions);
   } else {
     const extendsElement = overlayElement.get('extends');
     targetParseResult = extendsElement?.meta?.get('parseResult') as ParseResultElement;

--- a/packages/apidom-overlay/src/apply/realms/uri.ts
+++ b/packages/apidom-overlay/src/apply/realms/uri.ts
@@ -59,7 +59,7 @@ export const defaultOptions: ApplyOverlayOptions = {
  *
  * @param overlayURI - URI to the overlay document (file path or URL)
  * @param targetURI - URI to the target document; if omitted, uses the overlay's `extends` field
- * @param options - apidom-reference options + overlay merge options
+ * @param options - overlay apply options; reference options live under `options.reference`
  * @returns ParseResultElement with the modified target document
  *
  * @public
@@ -71,7 +71,7 @@ const applyOverlay = async (
 ): Promise<ParseResultElement> => {
   const mergedRefOptions = mergeOptions(
     defaultReferenceOptions as unknown as ReferenceOptions,
-    (options.reference ?? defaultReferenceOptions) as ReferenceOptions,
+    (options.reference ?? {}) as Record<string, unknown>,
   );
 
   // parse the overlay document along with document attached to `extends` field (if present)

--- a/packages/apidom-overlay/src/index.ts
+++ b/packages/apidom-overlay/src/index.ts
@@ -3,7 +3,11 @@ export {
   applyOverlay as applyOverlayApiDOM,
   type ApplyOptions,
 } from './apply/realms/apidom.ts';
-export { default as applyOverlay, type ApplyOverlayOptions } from './apply/realms/uri.ts';
+export {
+  default as applyOverlay,
+  defaultOptions as defaultApplyOverlayOptions,
+  type ApplyOverlayOptions,
+} from './apply/realms/uri.ts';
 export {
   applyAction as applyActionPOJO,
   applyOverlay as applyOverlayPOJO,

--- a/packages/apidom-overlay/test/apply/realms/apidom.ts
+++ b/packages/apidom-overlay/test/apply/realms/apidom.ts
@@ -1,5 +1,5 @@
 import { assert, expect } from 'chai';
-import { refract } from '@speclynx/apidom-datamodel';
+import { refract, ParseResultElement } from '@speclynx/apidom-datamodel';
 import { toValue, toJSON } from '@speclynx/apidom-core';
 import { refractAction, refractOverlay1 } from '@speclynx/apidom-ns-overlay-1';
 
@@ -663,6 +663,44 @@ describe('applyOverlayApiDOM', function () {
         () => applyOverlayApiDOM(notOverlay as unknown as Overlay1Element, target),
         OverlayError,
       );
+    });
+  });
+
+  context('generic ParseResultElement target (no api class)', function () {
+    specify('should apply overlay to generic JSON/YAML target', function () {
+      const overlay = refractOverlay1({
+        overlay: '1.1.0',
+        info: { title: 'Test', version: '1.0.0' },
+        actions: [{ target: '$.title', update: 'Updated' }],
+      });
+
+      const targetContent = refract({ title: 'Original', version: '1.0.0' });
+      targetContent.classes.push('result');
+      const targetParseResult = new ParseResultElement();
+      targetParseResult.push(targetContent);
+
+      const result = applyOverlayApiDOM(overlay, targetParseResult);
+      const value = toValue(result.result) as AnyJson;
+
+      assert.strictEqual(value.title, 'Updated');
+      assert.strictEqual(value.version, '1.0.0');
+    });
+
+    specify('should return ParseResultElement when given ParseResultElement', function () {
+      const overlay = refractOverlay1({
+        overlay: '1.1.0',
+        info: { title: 'Test', version: '1.0.0' },
+        actions: [{ target: '$.name', update: 'New Name' }],
+      });
+
+      const targetContent = refract({ name: 'Old Name' });
+      targetContent.classes.push('result');
+      const targetParseResult = new ParseResultElement();
+      targetParseResult.push(targetContent);
+
+      const result = applyOverlayApiDOM(overlay, targetParseResult);
+
+      assert.instanceOf(result, ParseResultElement);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Use `.result` instead of `.api` for target `ParseResultElement` — supports generic JSON/YAML documents, not just API definitions
- Scope reference options under `reference` key in `ApplyOverlayOptions` (breaking change, no external consumers yet)
- Export `defaultApplyOverlayOptions` for downstream reuse (e.g. `@speclynx/cli`)
- Add `type-fest` dependency for `PartialDeep` typing
- Add `options` parameter to POJO wrappers so trace/strict/immutable flow through
- Skip `replaceResult` when target reference is unchanged (mutable mode optimization)
- Add tests for generic `ParseResultElement` targets without `api` class

## Test plan

- [x] All 101 tests pass (`npm test` in `packages/apidom-overlay`)
- [x] Lint passes
- [x] New tests for generic ParseResultElement targets