### PR TITLE
fix(reference): prevent exponential tree growth on deref

### DIFF
--- a/packages/apidom-reference/src/dereference/strategies/arazzo-1/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/arazzo-1/visitor.ts
@@ -302,6 +302,7 @@ class Arazzo1DereferenceVisitor {
      * Transclude referencing element with merged referenced element.
      */
     path.replaceWith(mergedElement);
+    path.skip();
   }
 
   public async JSONSchemaElement(path: Path<Element>) {
@@ -478,6 +479,7 @@ class Arazzo1DereferenceVisitor {
           const replacement = replacer(refElement);
 
           path.replaceWith(replacement);
+          path.skip();
           return;
         }
       }
@@ -527,6 +529,7 @@ class Arazzo1DereferenceVisitor {
         booleanJsonSchemaElement.meta.set('ref-type', referencingElement.element);
 
         path.replaceWith(booleanJsonSchemaElement);
+        path.skip();
         return;
       }
 

--- a/packages/apidom-reference/src/dereference/strategies/asyncapi-2/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/asyncapi-2/visitor.ts
@@ -329,6 +329,7 @@ class AsyncAPI2DereferenceVisitor {
           const replacement = replacer(refElement);
 
           path.replaceWith(replacement);
+          path.skip();
           return;
         }
       }
@@ -379,6 +380,7 @@ class AsyncAPI2DereferenceVisitor {
         booleanJsonSchemaElement.meta.set('ref-type', referencingElement.element);
 
         path.replaceWith(booleanJsonSchemaElement);
+        path.skip();
         return;
       }
 
@@ -398,6 +400,7 @@ class AsyncAPI2DereferenceVisitor {
        * Transclude referencing element with merged referenced element.
        */
       path.replaceWith(mergedElement);
+      path.skip();
     } catch (error: unknown) {
       const $ref = toValue(referencingElement.$ref) as string;
       this.handleError(

--- a/packages/apidom-reference/src/dereference/strategies/openapi-2/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-2/visitor.ts
@@ -331,6 +331,7 @@ class OpenAPI2DereferenceVisitor {
           const replacement = replacer(refElement);
 
           path.replaceWith(replacement);
+          path.skip();
           return;
         }
       }
@@ -384,6 +385,7 @@ class OpenAPI2DereferenceVisitor {
        * Transclude referencing element with merged referenced element.
        */
       path.replaceWith(mergedElement);
+      path.skip();
     } catch (error: unknown) {
       const $ref = toValue(referencingElement.$ref) as string;
       this.handleError(
@@ -491,6 +493,7 @@ class OpenAPI2DereferenceVisitor {
           const replacement = replacer(refElement);
 
           path.replaceWith(replacement);
+          path.skip();
           return;
         }
       }
@@ -672,6 +675,7 @@ class OpenAPI2DereferenceVisitor {
           const replacement = replacer(refElement);
 
           path.replaceWith(replacement);
+          path.skip();
           return;
         }
       }
@@ -726,6 +730,7 @@ class OpenAPI2DereferenceVisitor {
        * Transclude referencing element with merged referenced element.
        */
       path.replaceWith(mergedElement);
+      path.skip();
     } catch (error: unknown) {
       const $ref = toValue(referencingElement.$ref) as string;
       this.handleError(

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-0/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-0/visitor.ts
@@ -333,6 +333,7 @@ class OpenAPI3_0DereferenceVisitor {
           const replacement = replacer(refElement);
 
           path.replaceWith(replacement);
+          path.skip();
           return;
         }
       }
@@ -387,6 +388,7 @@ class OpenAPI3_0DereferenceVisitor {
        * Transclude referencing element with merged referenced element.
        */
       path.replaceWith(mergedElement);
+      path.skip();
     } catch (error: unknown) {
       const $ref = toValue(referencingElement.$ref) as string;
       this.handleError(
@@ -494,6 +496,7 @@ class OpenAPI3_0DereferenceVisitor {
           const replacement = replacer(refElement);
 
           path.replaceWith(replacement);
+          path.skip();
           return;
         }
       }

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
@@ -347,6 +347,7 @@ class OpenAPI3_1DereferenceVisitor {
           const replacement = replacer(refElement);
 
           path.replaceWith(replacement);
+          path.skip();
           return;
         }
       }
@@ -524,6 +525,7 @@ class OpenAPI3_1DereferenceVisitor {
           const replacement = replacer(refElement);
 
           path.replaceWith(replacement);
+          path.skip();
           return;
         }
       }
@@ -958,6 +960,7 @@ class OpenAPI3_1DereferenceVisitor {
           const replacement = replacer(refElement);
 
           path.replaceWith(replacement);
+          path.skip();
           return;
         }
       }
@@ -1006,6 +1009,7 @@ class OpenAPI3_1DereferenceVisitor {
         booleanJsonSchemaElement.meta.set('ref-type', referencingElement.element);
 
         path.replaceWith(booleanJsonSchemaElement);
+        path.skip();
         return;
       }
 

--- a/packages/apidom-traverse/src/traversal.ts
+++ b/packages/apidom-traverse/src/traversal.ts
@@ -204,12 +204,6 @@ function* traverseGenerator<TNode>(
           break;
         }
 
-        if (currentPath.shouldSkip) {
-          if (!isLeaving) {
-            continue;
-          }
-        }
-
         if (currentPath.removed) {
           edits.push([key!, null]);
           if (!isLeaving) {
@@ -219,11 +213,18 @@ function* traverseGenerator<TNode>(
           const replacement = currentPath._getReplacementNode()!;
           edits.push([key!, replacement]);
           if (!isLeaving) {
+            if (currentPath.shouldSkip) {
+              continue;
+            }
             if (nodePredicate(replacement)) {
               node = replacement;
             } else {
               continue;
             }
+          }
+        } else if (currentPath.shouldSkip) {
+          if (!isLeaving) {
+            continue;
           }
         } else if (result !== undefined) {
           // Support return value replacement for backwards compatibility

--- a/packages/apidom-traverse/test/traversal.ts
+++ b/packages/apidom-traverse/test/traversal.ts
@@ -171,6 +171,56 @@ describe('traverse', function () {
     });
   });
 
+  context('path.replaceWith() + path.skip()', function () {
+    specify('should apply replacement but not traverse into its children', function () {
+      const root = new ObjectElement({ key: 'original' });
+      const replacement = new ObjectElement({ nested: 'value' });
+      const visited: string[] = [];
+
+      traverse(
+        root,
+        {
+          enter(path: Path) {
+            visited.push((path.node as Element).element);
+            if ((path.node as Element).element === 'object' && visited.length === 1) {
+              path.replaceWith(replacement);
+              path.skip();
+            }
+          },
+        },
+        { mutable: true },
+      );
+
+      // should only visit the root object, not the replacement's children
+      assert.deepEqual(visited, ['object']);
+    });
+
+    specify(
+      'should apply replacement but not traverse into its children (async)',
+      async function () {
+        const root = new ObjectElement({ key: 'original' });
+        const replacement = new ObjectElement({ nested: 'value' });
+        const visited: string[] = [];
+
+        await traverseAsync(
+          root,
+          {
+            async enter(path: Path) {
+              visited.push((path.node as Element).element);
+              if ((path.node as Element).element === 'object' && visited.length === 1) {
+                path.replaceWith(replacement);
+                path.skip();
+              }
+            },
+          },
+          { mutable: true },
+        );
+
+        assert.deepEqual(visited, ['object']);
+      },
+    );
+  });
+
   context('path.remove()', function () {
     specify('should remove node from array in mutable mode', function () {
       const root = new ArrayElement([1, 2, 3]);


### PR DESCRIPTION
## Summary

- Fix exponential tree growth when dereferencing large OpenAPI specs (e.g. Stripe API with 3,376 `$ref`s and 324K elements)
- Dereference time goes from **hanging indefinitely** to **~3.5 seconds**
- Regression was introduced in v2.0.0 (PR #12) when `visitAsync` with `keyMap`/`getNodeType` was replaced by `traverseAsync`

## Root Cause

When dereferencing with `{ mutable: true }`, after resolving a `$ref` via `path.replaceWith()`, `traverseAsync` descended into the replacement's children. Since the replacement shared structure with the mutable tree via `cloneShallow()`, already-resolved subtrees were re-traversed and re-expanded. This caused tree sizes to grow from 324K to 16.9M+ elements (`setup_intent` schema alone).

The old v1.x `visitAsync` engine avoided this because visitor methods returned `false` after replacement, which told the engine to skip traversal of the replacement's children.

## Fix

**apidom-traverse** (`traversal.ts`): Reorder control flow so that `replaceWith()` + `skip()` applies the replacement but does not descend into its children. Previously `skip()` was checked before `replaceWith()`, which silently dropped the replacement.

**apidom-reference** (all dereference visitor strategies): Add `path.skip()` after `path.replaceWith()` where the old v1.x code returned `false` (skip children):
- `ReferenceElement` main replacement and circular replacement (all strategies)
- `JSONReferenceElement` main and circular replacement (openapi-2)
- `ReusableElement` main replacement (arazzo-1)
- `JSONSchemaElement` circular and boolean replacements (arazzo-1)
- `SchemaElement` circular and boolean replacements (openapi-3-1)
- `PathItemElement` circular replacement (openapi-3-0, openapi-3-1, openapi-2)

Merge cases (`PathItemElement` main, `SchemaElement` main, `ChannelItemElement`) are left **without** `skip()` as their replacements may contain new content requiring further traversal.

## Test plan

- [x] All 1166 existing apidom-reference tests pass
- [x] Stripe API (3,376 internal `$ref`s): dereferences in ~3.5s (was hanging)
- [x] Sentry API (external `$ref`s): dereferences in ~7.9s
- [x] Verified against `@speclynx/apidom-reference@1.12.1` (v1.x) behavior: 5.9s for Stripe
