### PR TITLE
feat(core): add traverseOptions to dispatchRefractorPlugins

### DIFF
--- a/packages/apidom-core/src/refractor/plugins/dispatcher/index.ts
+++ b/packages/apidom-core/src/refractor/plugins/dispatcher/index.ts
@@ -4,6 +4,7 @@ import {
   traverseAsync,
   mergeVisitors,
   mergeVisitorsAsync,
+  type TraverseOptions,
 } from '@speclynx/apidom-traverse';
 import { mergeDeepRight, propOr } from 'ramda';
 import { invokeArgs } from 'ramda-adjunct';
@@ -18,6 +19,7 @@ export interface DispatchPluginsOptions {
   visitorOptions: {
     exposeEdits: boolean;
   };
+  traverseOptions?: TraverseOptions<Element>;
 }
 
 /**
@@ -60,7 +62,7 @@ export const dispatchPluginsSync: DispatchPluginsSync = ((element, plugins, opti
     defaultDispatchPluginsOptions,
     options,
   ) as DispatchPluginsOptions;
-  const { toolboxCreator, visitorOptions } = mergedOptions;
+  const { toolboxCreator, visitorOptions, traverseOptions } = mergedOptions;
   const toolbox = toolboxCreator();
   const pluginsSpecs = plugins.map((plugin) => plugin(toolbox));
   const mergedPluginsVisitor = mergeVisitors(
@@ -69,7 +71,7 @@ export const dispatchPluginsSync: DispatchPluginsSync = ((element, plugins, opti
   );
 
   pluginsSpecs.forEach(invokeArgs(['pre'], []));
-  const newElement = traverse(element, mergedPluginsVisitor);
+  const newElement = traverse(element, mergedPluginsVisitor, traverseOptions);
   pluginsSpecs.forEach(invokeArgs(['post'], []));
   return newElement;
 }) as DispatchPluginsSync;
@@ -85,7 +87,7 @@ export const dispatchPluginsAsync: DispatchPluginsAsync = (async (
     defaultDispatchPluginsOptions,
     options,
   ) as DispatchPluginsOptions;
-  const { toolboxCreator, visitorOptions } = mergedOptions;
+  const { toolboxCreator, visitorOptions, traverseOptions } = mergedOptions;
   const toolbox = toolboxCreator();
   const pluginsSpecs = plugins.map((plugin) => plugin(toolbox));
   const mergedPluginsVisitor = mergeVisitorsAsync(
@@ -94,7 +96,7 @@ export const dispatchPluginsAsync: DispatchPluginsAsync = (async (
   );
 
   await Promise.allSettled(pluginsSpecs.map(invokeArgs(['pre'], [])));
-  const newElement = await traverseAsync(element, mergedPluginsVisitor);
+  const newElement = await traverseAsync(element, mergedPluginsVisitor, traverseOptions);
   await Promise.allSettled(pluginsSpecs.map(invokeArgs(['post'], [])));
   return newElement;
 }) as DispatchPluginsAsync;

--- a/packages/apidom-core/src/refractor/plugins/dispatcher/index.ts
+++ b/packages/apidom-core/src/refractor/plugins/dispatcher/index.ts
@@ -29,7 +29,7 @@ export interface DispatchPluginsSync {
   <T extends Element, U extends Element = Element>(
     element: T,
     plugins: ((toolbox: any) => object)[],
-    options?: Record<string, unknown>,
+    options?: Partial<DispatchPluginsOptions>,
   ): U;
   [key: symbol]: DispatchPluginsAsync;
 }
@@ -41,7 +41,7 @@ export interface DispatchPluginsAsync {
   <T extends Element, U extends Element = Element>(
     element: T,
     plugins: ((toolbox: any) => object)[],
-    options?: Record<string, unknown>,
+    options?: Partial<DispatchPluginsOptions>,
   ): Promise<U>;
 }
 

--- a/packages/apidom-core/src/refractor/plugins/dispatcher/index.ts
+++ b/packages/apidom-core/src/refractor/plugins/dispatcher/index.ts
@@ -29,7 +29,7 @@ export interface DispatchPluginsSync {
   <T extends Element, U extends Element = Element>(
     element: T,
     plugins: ((toolbox: any) => object)[],
-    options?: Partial<DispatchPluginsOptions>,
+    options?: Record<string, unknown>,
   ): U;
   [key: symbol]: DispatchPluginsAsync;
 }
@@ -41,7 +41,7 @@ export interface DispatchPluginsAsync {
   <T extends Element, U extends Element = Element>(
     element: T,
     plugins: ((toolbox: any) => object)[],
-    options?: Partial<DispatchPluginsOptions>,
+    options?: Record<string, unknown>,
   ): Promise<U>;
 }
 

--- a/packages/apidom-core/test/refractor/plugins/dispatcher/index.ts
+++ b/packages/apidom-core/test/refractor/plugins/dispatcher/index.ts
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import { assert } from 'chai';
 import { ApiDOMStructuredError } from '@speclynx/apidom-error';
-import { NumberElement, ObjectElement } from '@speclynx/apidom-datamodel';
+import { Element, NumberElement, ObjectElement } from '@speclynx/apidom-datamodel';
 import { Path } from '@speclynx/apidom-traverse';
 
 import { toValue, dispatchRefractorPlugins as dispatchPluginsSync } from '../../../../src/index.ts';
@@ -58,7 +58,7 @@ describe('refrator', function () {
           const visited: string[] = [];
           const plugin = () => ({
             visitor: {
-              enter(path: Path<NumberElement>) {
+              enter(path: Path<Element>) {
                 visited.push(path.node.element);
               },
             },

--- a/packages/apidom-core/test/refractor/plugins/dispatcher/index.ts
+++ b/packages/apidom-core/test/refractor/plugins/dispatcher/index.ts
@@ -53,6 +53,38 @@ describe('refrator', function () {
             'Async visitor not supported in sync mode',
           );
         });
+
+        specify('should pass traverseOptions to traverse', function () {
+          const visited: string[] = [];
+          const plugin = () => ({
+            visitor: {
+              enter(path: Path<NumberElement>) {
+                visited.push(path.node.element);
+              },
+            },
+          });
+
+          // create a tree with shared nodes (DAG)
+          const shared = new NumberElement(1);
+          const objectElement = new ObjectElement({});
+          objectElement.set('a', shared);
+          objectElement.set('b', shared);
+
+          // without skipVisited, shared node is visited twice
+          visited.length = 0;
+          dispatchPluginsSync(objectElement, [plugin]);
+          const withoutSkip = visited.filter((e) => e === 'number').length;
+
+          // with skipVisited, shared node is visited once
+          visited.length = 0;
+          dispatchPluginsSync(objectElement, [plugin], {
+            traverseOptions: { skipVisited: true },
+          });
+          const withSkip = visited.filter((e) => e === 'number').length;
+
+          assert.strictEqual(withoutSkip, 2);
+          assert.strictEqual(withSkip, 1);
+        });
       });
 
       context('dispatchPluginsASync', function () {


### PR DESCRIPTION
## Summary

- Add `traverseOptions` property to `DispatchPluginsOptions`, allowing callers to pass options (like `skipVisited`) through to the underlying `traverse`/`traverseAsync` calls
- Enables using `dispatchRefractorPlugins` with `{ traverseOptions: { skipVisited: true } }` for safe traversal of dereferenced trees

## Test plan

- [x] New test verifying `traverseOptions.skipVisited` is forwarded to traverse
- [x] All 166 apidom-core tests pass
- [x] All 1166 apidom-reference tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)