### PR TITLE
fix(ns-overlay-1): add actions mappings to replaceEmptyElement plugin

### DIFF
--- a/packages/apidom-ns-overlay-1/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-overlay-1/src/refractor/plugins/replace-empty-element.ts
@@ -68,7 +68,8 @@ const schema: Record<string, Record<string, ElementFactory>> = {
   // concrete types handling (CTs)
   Overlay1Element: {
     info: (content, meta, attributes) => new InfoElement(content, meta, attributes),
-    actions: (content, meta, attributes) => new Actions(content, meta, attributes),
+    actions: (content, meta, attributes) =>
+      new Actions(content as unknown as Array<unknown> | undefined, meta, attributes),
   },
   // non-concrete types handling (NCEs)
   [Actions.primaryClass]: {

--- a/packages/apidom-ns-overlay-1/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-overlay-1/src/refractor/plugins/replace-empty-element.ts
@@ -18,6 +18,8 @@ import { toValue } from '@speclynx/apidom-core';
  * Overlay 1.1.0 specification elements.
  */
 import InfoElement from '../../elements/Info.ts';
+import ActionElement from '../../elements/Action.ts';
+import Actions from '../../elements/nces/Actions.ts';
 
 /**
  * This plugin is specific to YAML 1.2 format, which allows defining key-value pairs
@@ -66,6 +68,11 @@ const schema: Record<string, Record<string, ElementFactory>> = {
   // concrete types handling (CTs)
   Overlay1Element: {
     info: (content, meta, attributes) => new InfoElement(content, meta, attributes),
+    actions: (content, meta, attributes) => new Actions(content, meta, attributes),
+  },
+  // non-concrete types handling (NCEs)
+  [Actions.primaryClass]: {
+    '<*>': (content, meta, attributes) => new ActionElement(content, meta, attributes),
   },
 };
 

--- a/packages/apidom-ns-overlay-1/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
+++ b/packages/apidom-ns-overlay-1/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`given empty value instead of Actions should replace empty value with semantic element 1`] = `
+(Overlay1Element
+  (MemberElement
+    (StringElement)
+    (OverlayElement))
+  (MemberElement
+    (StringElement)
+    (ArrayElement)))
+`;
+
 exports[`given empty value instead of InfoElement should replace empty value with semantic element 1`] = `
 (Overlay1Element
   (MemberElement

--- a/packages/apidom-ns-overlay-1/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
+++ b/packages/apidom-ns-overlay-1/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`given empty value instead of ActionElement should replace empty value with semantic element 1`] = `
+(Overlay1Element
+  (MemberElement
+    (StringElement)
+    (OverlayElement))
+  (MemberElement
+    (StringElement)
+    (ArrayElement
+      (ActionElement))))
+`;
+
+exports[`given multiple empty values instead of ActionElement should replace empty values with semantic elements 1`] = `
+(Overlay1Element
+  (MemberElement
+    (StringElement)
+    (OverlayElement))
+  (MemberElement
+    (StringElement)
+    (ArrayElement
+      (ActionElement)
+      (ActionElement))))
+`;

--- a/packages/apidom-ns-overlay-1/test/refractor/plugins/replace-empty-element/mappings.ts
+++ b/packages/apidom-ns-overlay-1/test/refractor/plugins/replace-empty-element/mappings.ts
@@ -25,6 +25,21 @@ describe('given empty value instead of InfoElement', function () {
   });
 });
 
+describe('given empty value instead of Actions', function () {
+  it('should replace empty value with semantic element', async function () {
+    const yamlDefinition = dedent`
+      overlay: 1.1.0
+      actions:
+    `;
+    const apiDOM = await parse(yamlDefinition);
+    const overlay1Element = refractOverlay1(apiDOM.result, {
+      plugins: [refractorPluginReplaceEmptyElement()],
+    });
+
+    expect(sexprs(overlay1Element)).toMatchSnapshot();
+  });
+});
+
 describe('given Overlay definition with empty values', function () {
   it('should generate proper source maps', async function () {
     const yamlDefinition = dedent`

--- a/packages/apidom-ns-overlay-1/test/refractor/plugins/replace-empty-element/sequences.ts
+++ b/packages/apidom-ns-overlay-1/test/refractor/plugins/replace-empty-element/sequences.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import dedent from 'dedent';
+import { sexprs } from '@speclynx/apidom-core';
+import { parse } from '@speclynx/apidom-parser-adapter-yaml-1-2';
+
+import { refractorPluginReplaceEmptyElement, refractOverlay1 } from '../../../../src/index.ts';
+
+describe('given empty value instead of ActionElement', function () {
+  it('should replace empty value with semantic element', async function () {
+    const yamlDefinition = dedent`
+      overlay: 1.1.0
+      actions:
+       -
+    `;
+    const apiDOM = await parse(yamlDefinition);
+    const overlay1Element = refractOverlay1(apiDOM.result, {
+      plugins: [refractorPluginReplaceEmptyElement()],
+    });
+
+    expect(sexprs(overlay1Element)).toMatchSnapshot();
+  });
+});
+
+describe('given multiple empty values instead of ActionElement', function () {
+  it('should replace empty values with semantic elements', async function () {
+    const yamlDefinition = dedent`
+      overlay: 1.1.0
+      actions:
+       -
+       -
+    `;
+    const apiDOM = await parse(yamlDefinition);
+    const overlay1Element = refractOverlay1(apiDOM.result, {
+      plugins: [refractorPluginReplaceEmptyElement()],
+    });
+
+    expect(sexprs(overlay1Element)).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `actions` and `<*>` (action array item) mappings to the `replaceEmptyElement` refractor plugin for `@speclynx/apidom-ns-overlay-1`
- Empty YAML values for `actions:` are now replaced with `Actions` (ArrayElement), and empty array items within actions are replaced with `ActionElement`
- Previously only `info` was mapped, so empty actions produced generic `StringElement` instead of semantic types

## Test plan

- [x] Added test for empty `actions:` value replacement (mappings)
- [x] Added test for single empty action array item replacement (sequences)
- [x] Added test for multiple empty action array items replacement (sequences)
- [x] All 32 existing + new tests pass