### PR TITLE
feat(traverse): skipVisited 'enter-only' mode and path.revisited

### DIFF
--- a/packages/apidom-core/test/refractor/plugins/dispatcher/index.ts
+++ b/packages/apidom-core/test/refractor/plugins/dispatcher/index.ts
@@ -78,7 +78,7 @@ describe('refrator', function () {
           // with skipVisited, shared node is visited once
           visited.length = 0;
           dispatchPluginsSync(objectElement, [plugin], {
-            traverseOptions: { skipVisited: true },
+            traverseOptions: { skipVisited: 'skip' },
           });
           const withSkip = visited.filter((e) => e === 'number').length;
 

--- a/packages/apidom-reference/src/dereference/strategies/arazzo-1/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/arazzo-1/index.ts
@@ -105,7 +105,7 @@ class Arazzo1DereferenceStrategy extends DereferenceStrategy {
     const visitor = new Arazzo1DereferenceVisitor({ reference, options });
     const dereferencedElement = await traverseAsync(refSet.rootRef!.value, visitor, {
       mutable: true,
-      ...(shouldDetectCircular && { skipVisited: true }),
+      ...(shouldDetectCircular && { skipVisited: 'skip' as const }),
     });
 
     /**

--- a/packages/apidom-reference/src/dereference/strategies/arazzo-1/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/arazzo-1/visitor.ts
@@ -523,7 +523,7 @@ class Arazzo1DereferenceVisitor {
         });
         referencedElement = await traverseAsync(referencedElement, visitor, {
           mutable: true,
-          skipVisited: true,
+          skipVisited: 'skip',
         });
 
         // remove referencing reference from ancestors lineage

--- a/packages/apidom-reference/src/dereference/strategies/asyncapi-2/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/asyncapi-2/index.ts
@@ -98,7 +98,7 @@ class AsyncAPI2DereferenceStrategy extends DereferenceStrategy {
     const visitor = new AsyncAPI2DereferenceVisitor({ reference, options });
     const dereferencedElement = await traverseAsync(refSet.rootRef!.value, visitor, {
       mutable: true,
-      ...(shouldDetectCircular && { skipVisited: true }),
+      ...(shouldDetectCircular && { skipVisited: 'skip' as const }),
     });
 
     /**

--- a/packages/apidom-reference/src/dereference/strategies/asyncapi-2/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/asyncapi-2/visitor.ts
@@ -374,7 +374,7 @@ class AsyncAPI2DereferenceVisitor {
         });
         referencedElement = await traverseAsync(referencedElement, visitor, {
           mutable: true,
-          skipVisited: true,
+          skipVisited: 'skip',
         });
 
         // remove referencing reference from ancestors lineage
@@ -560,7 +560,7 @@ class AsyncAPI2DereferenceVisitor {
         });
         referencedElement = await traverseAsync(referencedElement, visitor, {
           mutable: true,
-          skipVisited: true,
+          skipVisited: 'skip',
         });
 
         // remove referencing reference from ancestors lineage

--- a/packages/apidom-reference/src/dereference/strategies/openapi-2/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-2/index.ts
@@ -99,7 +99,7 @@ class OpenAPI2DereferenceStrategy extends DereferenceStrategy {
     const visitor = new OpenAPI2DereferenceVisitor({ reference: reference!, options });
     const dereferencedElement = await traverseAsync(refSet.rootRef!.value, visitor, {
       mutable: true,
-      ...(shouldDetectCircular && { skipVisited: true }),
+      ...(shouldDetectCircular && { skipVisited: 'skip' as const }),
     });
 
     /**

--- a/packages/apidom-reference/src/dereference/strategies/openapi-2/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-2/visitor.ts
@@ -376,7 +376,7 @@ class OpenAPI2DereferenceVisitor {
         });
         referencedElement = await traverseAsync(referencedElement, visitor, {
           mutable: true,
-          skipVisited: true,
+          skipVisited: 'skip',
         });
 
         directAncestors.delete(referencingElement);
@@ -546,7 +546,7 @@ class OpenAPI2DereferenceVisitor {
         });
         referencedElement = await traverseAsync(referencedElement, visitor, {
           mutable: true,
-          skipVisited: true,
+          skipVisited: 'skip',
         });
 
         // remove referencing reference from ancestors lineage
@@ -736,7 +736,7 @@ class OpenAPI2DereferenceVisitor {
         });
         referencedElement = await traverseAsync(referencedElement, visitor, {
           mutable: true,
-          skipVisited: true,
+          skipVisited: 'skip',
         });
 
         // remove referencing reference from ancestors lineage

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-0/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-0/index.ts
@@ -99,7 +99,7 @@ class OpenAPI3_0DereferenceStrategy extends DereferenceStrategy {
     const visitor = new OpenAPI3_0DereferenceVisitor({ reference: reference!, options });
     const dereferencedElement = await traverseAsync(refSet.rootRef!.value, visitor, {
       mutable: true,
-      ...(shouldDetectCircular && { skipVisited: true }),
+      ...(shouldDetectCircular && { skipVisited: 'skip' as const }),
     });
 
     /**

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-0/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-0/visitor.ts
@@ -378,7 +378,7 @@ class OpenAPI3_0DereferenceVisitor {
         });
         referencedElement = await traverseAsync(referencedElement, visitor, {
           mutable: true,
-          skipVisited: true,
+          skipVisited: 'skip',
         });
 
         // remove referencing reference from ancestors lineage
@@ -549,7 +549,7 @@ class OpenAPI3_0DereferenceVisitor {
         });
         referencedElement = await traverseAsync(referencedElement, visitor, {
           mutable: true,
-          skipVisited: true,
+          skipVisited: 'skip',
         });
 
         // remove referencing reference from ancestors lineage

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1/index.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1/index.ts
@@ -100,7 +100,7 @@ class OpenAPI3_1DereferenceStrategy extends DereferenceStrategy {
 
     const dereferencedElement = await traverseAsync(refSet.rootRef!.value, visitor, {
       mutable: true,
-      ...(shouldDetectCircular && { skipVisited: true }),
+      ...(shouldDetectCircular && { skipVisited: 'skip' as const }),
     });
 
     /**

--- a/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/openapi-3-1/visitor.ts
@@ -391,7 +391,7 @@ class OpenAPI3_1DereferenceVisitor {
         });
         referencedElement = await traverseAsync(referencedElement, visitor, {
           mutable: true,
-          skipVisited: true,
+          skipVisited: 'skip',
         });
 
         directAncestors.delete(referencingElement);
@@ -577,7 +577,7 @@ class OpenAPI3_1DereferenceVisitor {
         });
         referencedElement = await traverseAsync(referencedElement, visitor, {
           mutable: true,
-          skipVisited: true,
+          skipVisited: 'skip',
         });
 
         directAncestors.delete(referencingElement);
@@ -1020,7 +1020,7 @@ class OpenAPI3_1DereferenceVisitor {
         });
         referencedElement = await traverseAsync(referencedElement, visitor, {
           mutable: true,
-          skipVisited: true,
+          skipVisited: 'skip',
         });
 
         directAncestors.delete(referencingElement);

--- a/packages/apidom-traverse/src/Path.ts
+++ b/packages/apidom-traverse/src/Path.ts
@@ -63,8 +63,10 @@ export class Path<TNode = Element> {
   public readonly inList: boolean;
 
   /**
-   * True when this enter is a non-descending revisit of an already-visited node
+   * True when this node is a non-descending revisit of an already-visited node
    * (only under skipVisited: 'enter-only'). Children are not traversed.
+   * Set on both the enter and the matching leave phase, so it is meaningful
+   * in either phase.
    */
   public revisited: boolean = false;
 

--- a/packages/apidom-traverse/src/Path.ts
+++ b/packages/apidom-traverse/src/Path.ts
@@ -63,6 +63,12 @@ export class Path<TNode = Element> {
   public readonly inList: boolean;
 
   /**
+   * True when this enter is a non-descending revisit of an already-visited node
+   * (only under skipVisited: 'enter-only'). Children are not traversed.
+   */
+  public revisited: boolean = false;
+
+  /**
    * Internal state for traversal control.
    */
   #shouldSkip: boolean = false;

--- a/packages/apidom-traverse/src/index.ts
+++ b/packages/apidom-traverse/src/index.ts
@@ -30,7 +30,7 @@ export type {
   MergedVisitorAsync,
 } from './visitors.ts';
 export { traverse, traverseAsync } from './traversal.ts';
-export type { TraverseOptions } from './traversal.ts';
+export type { TraverseOptions, SkipVisitedMode } from './traversal.ts';
 
 // Operations
 export { default as filter } from './operations/filter.ts';

--- a/packages/apidom-traverse/src/traversal.ts
+++ b/packages/apidom-traverse/src/traversal.ts
@@ -86,11 +86,6 @@ const normalizeSkipVisited = (v: boolean | SkipVisitedMode | undefined): SkipVis
   return v;
 };
 
-// Resolved options as seen by the generator: skipVisited is narrowed to its canonical string.
-type ResolvedTraverseOptions<TNode> = Omit<Required<TraverseOptions<TNode>>, 'skipVisited'> & {
-  skipVisited: SkipVisitedMode;
-};
-
 interface VisitorCall<TNode> {
   visitFn: VisitorFn<TNode>;
   path: Path<TNode>;
@@ -114,7 +109,7 @@ interface TraversalState<TNode> {
 function* traverseGenerator<TNode>(
   root: TNode,
   visitor: object,
-  options: ResolvedTraverseOptions<TNode>,
+  options: Required<TraverseOptions<TNode>>,
 ): Generator<VisitorCall<TNode>, TNode, VisitorResult<TNode>> {
   const {
     keyMap,
@@ -379,7 +374,7 @@ export const traverse = <TNode>(
   visitor: object,
   options: TraverseOptions<TNode> = {},
 ): TNode => {
-  const resolvedOptions: ResolvedTraverseOptions<TNode> = {
+  const resolvedOptions: Required<TraverseOptions<TNode>> = {
     keyMap: options.keyMap ?? (getNodeKeys as (node: TNode) => readonly string[]),
     state: options.state ?? {},
     nodeTypeGetter: options.nodeTypeGetter ?? (getNodeType as (node: TNode) => string | undefined),
@@ -420,7 +415,7 @@ export const traverseAsync = async <TNode>(
   visitor: object,
   options: TraverseOptions<TNode> = {},
 ): Promise<TNode> => {
-  const resolvedOptions: ResolvedTraverseOptions<TNode> = {
+  const resolvedOptions: Required<TraverseOptions<TNode>> = {
     keyMap: options.keyMap ?? (getNodeKeys as (node: TNode) => readonly string[]),
     state: options.state ?? {},
     nodeTypeGetter: options.nodeTypeGetter ?? (getNodeType as (node: TNode) => string | undefined),

--- a/packages/apidom-traverse/src/traversal.ts
+++ b/packages/apidom-traverse/src/traversal.ts
@@ -44,17 +44,20 @@ export interface TraverseOptions<TNode> {
   detectCycles?: boolean;
   /**
    * Controls handling of already-visited nodes (by identity, via a WeakSet).
-   * Defaults to false.
-   * - false / 'never' : no skipping (default).
-   * - true  / 'skip'  : skip the node entirely on re-encounter (no enter/leave, no descent).
-   * - 'enter-only'    : on re-encounter still fire enter/leave, but DO NOT descend into
-   *                     the (already-walked) subtree. Lets visitors observe every
-   *                     occurrence of a shared node while preserving the
-   *                     no-combinatorial-explosion guarantee.
+   * Defaults to 'never'.
+   * - 'never'      : no skipping (default).
+   * - 'skip'       : skip the node entirely on re-encounter (no enter/leave, no descent).
+   * - 'enter-only' : on re-encounter still fire enter/leave, but DO NOT descend into
+   *                  the (already-walked) subtree. Lets visitors observe every
+   *                  occurrence of a shared node while preserving the
+   *                  no-combinatorial-explosion guarantee.
    * Useful for traversing dereferenced trees that contain shared structure
    * from cloneShallow (DAG) which would otherwise cause combinatorial explosion.
+   *
+   * Legacy booleans are still accepted at runtime for backward compatibility:
+   * `false` maps to 'never' and `true` maps to 'skip'.
    */
-  skipVisited?: boolean | 'never' | 'skip' | 'enter-only';
+  skipVisited?: 'never' | 'skip' | 'enter-only';
   /**
    * If true, edits modify the original tree in place.
    * If false (default), creates a new tree with changes applied.

--- a/packages/apidom-traverse/src/traversal.ts
+++ b/packages/apidom-traverse/src/traversal.ts
@@ -43,13 +43,18 @@ export interface TraverseOptions<TNode> {
    */
   detectCycles?: boolean;
   /**
-   * Whether to skip already-visited nodes. Defaults to false.
-   * When true, uses a WeakSet to track visited nodes and skips any node
-   * encountered a second time, regardless of the path taken to reach it.
+   * Controls handling of already-visited nodes (by identity, via a WeakSet).
+   * Defaults to false.
+   * - false / 'never' : no skipping (default).
+   * - true  / 'skip'  : skip the node entirely on re-encounter (no enter/leave, no descent).
+   * - 'enter-only'    : on re-encounter still fire enter/leave, but DO NOT descend into
+   *                     the (already-walked) subtree. Lets visitors observe every
+   *                     occurrence of a shared node while preserving the
+   *                     no-combinatorial-explosion guarantee.
    * Useful for traversing dereferenced trees that contain shared structure
    * from cloneShallow (DAG) which would otherwise cause combinatorial explosion.
    */
-  skipVisited?: boolean;
+  skipVisited?: boolean | 'never' | 'skip' | 'enter-only';
   /**
    * If true, edits modify the original tree in place.
    * If false (default), creates a new tree with changes applied.
@@ -66,6 +71,19 @@ export interface TraverseOptions<TNode> {
 // Internal types for generator
 // =============================================================================
 
+type SkipVisitedMode = 'never' | 'skip' | 'enter-only';
+
+const normalizeSkipVisited = (v: boolean | SkipVisitedMode | undefined): SkipVisitedMode => {
+  if (v === true) return 'skip';
+  if (v === false || v === undefined) return 'never';
+  return v;
+};
+
+// Resolved options as seen by the generator: skipVisited is narrowed to its canonical string.
+type ResolvedTraverseOptions<TNode> = Omit<Required<TraverseOptions<TNode>>, 'skipVisited'> & {
+  skipVisited: SkipVisitedMode;
+};
+
 interface VisitorCall<TNode> {
   visitFn: VisitorFn<TNode>;
   path: Path<TNode>;
@@ -78,6 +96,7 @@ interface TraversalState<TNode> {
   keys: readonly PropertyKey[] | TNode[];
   edits: Array<[PropertyKey, TNode | null]>;
   parentPath: Path<TNode> | null;
+  revisitNoDescend: boolean;
   prev: TraversalState<TNode> | undefined;
 }
 
@@ -88,7 +107,7 @@ interface TraversalState<TNode> {
 function* traverseGenerator<TNode>(
   root: TNode,
   visitor: object,
-  options: Required<TraverseOptions<TNode>>,
+  options: ResolvedTraverseOptions<TNode>,
 ): Generator<VisitorCall<TNode>, TNode, VisitorResult<TNode>> {
   const {
     keyMap,
@@ -102,7 +121,7 @@ function* traverseGenerator<TNode>(
     mutationFn,
   } = options;
   const keyMapIsFunction = typeof keyMap === 'function';
-  const visitedNodes = skipVisited ? new WeakSet<object>() : null;
+  const visitedNodes = skipVisited !== 'never' ? new WeakSet<object>() : null;
 
   let stack: TraversalState<TNode> | undefined;
   let inArray = Array.isArray(root);
@@ -119,6 +138,7 @@ function* traverseGenerator<TNode>(
     index += 1;
     const isLeaving = index === keys.length;
     let key: PropertyKey | undefined;
+    let revisitNoDescend = false;
     const isEdited = isLeaving && edits.length !== 0;
 
     if (isLeaving) {
@@ -163,6 +183,7 @@ function* traverseGenerator<TNode>(
         edits = stack.edits;
         const parentInArray = stack.inArray;
         parentPath = stack.parentPath;
+        revisitNoDescend = stack.revisitNoDescend;
         stack = stack.prev;
 
         // Push the edited node to parent's edits for propagation up the tree
@@ -193,15 +214,22 @@ function* traverseGenerator<TNode>(
       }
 
       // Skip already-visited nodes (handles DAG structures from cloneShallow)
-      if (skipVisited && !isLeaving) {
+      if (skipVisited !== 'never' && !isLeaving) {
         if (visitedNodes!.has(node as object)) {
-          continue;
+          if (skipVisited === 'enter-only') {
+            // fire enter/leave for this occurrence, but don't re-descend
+            revisitNoDescend = true;
+          } else {
+            continue;
+          }
+        } else {
+          visitedNodes!.add(node as object);
         }
-        visitedNodes!.add(node as object);
       }
 
       // Always create Path for the current node (needed for parentPath chain)
       currentPath = new Path<TNode>(node, parent, parentPath, key, inArray);
+      currentPath.revisited = revisitNoDescend;
 
       const visitFn = getVisitFn<TNode>(visitor, nodeTypeGetter(node), isLeaving);
 
@@ -263,9 +291,11 @@ function* traverseGenerator<TNode>(
     }
 
     if (!isLeaving) {
-      stack = { inArray, index, keys, edits, parentPath, prev: stack };
+      stack = { inArray, index, keys, edits, parentPath, revisitNoDescend, prev: stack };
       inArray = Array.isArray(node);
-      if (inArray) {
+      if (revisitNoDescend) {
+        keys = [];
+      } else if (inArray) {
         keys = node as unknown as TNode[];
       } else if (keyMapIsFunction) {
         keys = keyMap(node);
@@ -342,14 +372,14 @@ export const traverse = <TNode>(
   visitor: object,
   options: TraverseOptions<TNode> = {},
 ): TNode => {
-  const resolvedOptions: Required<TraverseOptions<TNode>> = {
+  const resolvedOptions: ResolvedTraverseOptions<TNode> = {
     keyMap: options.keyMap ?? (getNodeKeys as (node: TNode) => readonly string[]),
     state: options.state ?? {},
     nodeTypeGetter: options.nodeTypeGetter ?? (getNodeType as (node: TNode) => string | undefined),
     nodePredicate: options.nodePredicate ?? (isNode as (value: unknown) => value is TNode),
     nodeCloneFn: options.nodeCloneFn ?? (cloneNode as (node: TNode) => TNode),
     detectCycles: options.detectCycles ?? true,
-    skipVisited: options.skipVisited ?? false,
+    skipVisited: normalizeSkipVisited(options.skipVisited),
     mutable: options.mutable ?? false,
     mutationFn: options.mutationFn ?? mutateNode,
   };
@@ -383,14 +413,14 @@ export const traverseAsync = async <TNode>(
   visitor: object,
   options: TraverseOptions<TNode> = {},
 ): Promise<TNode> => {
-  const resolvedOptions: Required<TraverseOptions<TNode>> = {
+  const resolvedOptions: ResolvedTraverseOptions<TNode> = {
     keyMap: options.keyMap ?? (getNodeKeys as (node: TNode) => readonly string[]),
     state: options.state ?? {},
     nodeTypeGetter: options.nodeTypeGetter ?? (getNodeType as (node: TNode) => string | undefined),
     nodePredicate: options.nodePredicate ?? (isNode as (value: unknown) => value is TNode),
     nodeCloneFn: options.nodeCloneFn ?? (cloneNode as (node: TNode) => TNode),
     detectCycles: options.detectCycles ?? true,
-    skipVisited: options.skipVisited ?? false,
+    skipVisited: normalizeSkipVisited(options.skipVisited),
     mutable: options.mutable ?? false,
     mutationFn: options.mutationFn ?? mutateNode,
   };

--- a/packages/apidom-traverse/src/traversal.ts
+++ b/packages/apidom-traverse/src/traversal.ts
@@ -12,6 +12,12 @@ import type { VisitorFn, VisitorResult } from './Path.ts';
 import { getNodeType, isNode, cloneNode, mutateNode, getVisitFn, getNodeKeys } from './visitors.ts';
 
 /**
+ * Controls handling of already-visited nodes during traversal.
+ * @public
+ */
+export type SkipVisitedMode = 'never' | 'skip' | 'enter-only';
+
+/**
  * Options for the traverse function.
  * @public
  */
@@ -57,7 +63,7 @@ export interface TraverseOptions<TNode> {
    * Legacy booleans are still accepted at runtime for backward compatibility:
    * `false` maps to 'never' and `true` maps to 'skip'.
    */
-  skipVisited?: 'never' | 'skip' | 'enter-only';
+  skipVisited?: SkipVisitedMode;
   /**
    * If true, edits modify the original tree in place.
    * If false (default), creates a new tree with changes applied.
@@ -73,8 +79,6 @@ export interface TraverseOptions<TNode> {
 // =============================================================================
 // Internal types for generator
 // =============================================================================
-
-type SkipVisitedMode = 'never' | 'skip' | 'enter-only';
 
 const normalizeSkipVisited = (v: boolean | SkipVisitedMode | undefined): SkipVisitedMode => {
   if (v === true) return 'skip';

--- a/packages/apidom-traverse/src/visitors.ts
+++ b/packages/apidom-traverse/src/visitors.ts
@@ -502,11 +502,13 @@ export const mergeVisitorsAsync = <TNode>(
  * @internal
  */
 function createPathProxy<TNode>(originalPath: Path<TNode>, currentNode: TNode): Path<TNode> {
-  return new Path<TNode>(
+  const proxy = new Path<TNode>(
     currentNode,
     originalPath.parent,
     originalPath.parentPath,
     originalPath.key,
     originalPath.inList,
   );
+  proxy.revisited = originalPath.revisited;
+  return proxy;
 }

--- a/packages/apidom-traverse/test/traversal.ts
+++ b/packages/apidom-traverse/test/traversal.ts
@@ -398,7 +398,8 @@ describe('traverse', function () {
               }
             },
           },
-          { skipVisited: true },
+          // legacy boolean accepted at runtime for backward compatibility
+          { skipVisited: true as unknown as 'skip' },
         );
 
         // shared node entered once, never revisited

--- a/packages/apidom-traverse/test/traversal.ts
+++ b/packages/apidom-traverse/test/traversal.ts
@@ -306,6 +306,133 @@ describe('traverse', function () {
     });
   });
 
+  context('skipVisited', function () {
+    // Build a DAG: one shared ObjectElement reachable via two members of the root.
+    const buildDag = () => {
+      const shared = new ObjectElement({ shared: 'leaf' });
+      const root = new ObjectElement();
+      root.set('a', shared);
+      root.set('b', shared);
+      return { root, shared };
+    };
+
+    context("given 'enter-only'", function () {
+      specify('should re-fire enter/leave on revisit without descending', function () {
+        const { root, shared } = buildDag();
+        const sharedEnters: boolean[] = [];
+        const sharedLeaves: boolean[] = [];
+        let leafEnters = 0;
+
+        traverse(
+          root,
+          {
+            ObjectElement: {
+              enter(path: Path) {
+                if (path.node === shared) {
+                  sharedEnters.push(path.revisited);
+                }
+              },
+              leave(path: Path) {
+                if (path.node === shared) {
+                  sharedLeaves.push(path.revisited);
+                }
+              },
+            },
+            StringElement(path: Path) {
+              if ((path.node as StringElement).toValue() === 'leaf') {
+                leafEnters += 1;
+              }
+            },
+          },
+          { skipVisited: 'enter-only' },
+        );
+
+        // shared node enters/leaves on both encounters
+        assert.lengthOf(sharedEnters, 2);
+        assert.lengthOf(sharedLeaves, 2);
+        // revisited is false on first encounter, true on second (enter and leave)
+        assert.deepEqual(sharedEnters, [false, true]);
+        assert.deepEqual(sharedLeaves, [false, true]);
+        // children of the shared node are walked only once (no re-descent)
+        assert.strictEqual(leafEnters, 1);
+      });
+
+      specify('should always leave first-visit nodes with revisited=false', function () {
+        const { root } = buildDag();
+        const rootLeaves: boolean[] = [];
+
+        traverse(
+          root,
+          {
+            enter() {},
+            leave(path: Path) {
+              if (path.isRoot()) {
+                rootLeaves.push(path.revisited);
+              }
+            },
+          },
+          { skipVisited: 'enter-only' },
+        );
+
+        assert.deepEqual(rootLeaves, [false]);
+      });
+    });
+
+    context("given true ('skip')", function () {
+      specify('should skip revisited nodes entirely (no enter/leave, no descent)', function () {
+        const { root, shared } = buildDag();
+        let sharedEnters = 0;
+        let leafEnters = 0;
+
+        traverse(
+          root,
+          {
+            ObjectElement(path: Path) {
+              if (path.node === shared) {
+                sharedEnters += 1;
+              }
+            },
+            StringElement(path: Path) {
+              if ((path.node as StringElement).toValue() === 'leaf') {
+                leafEnters += 1;
+              }
+            },
+          },
+          { skipVisited: true },
+        );
+
+        // shared node entered once, never revisited
+        assert.strictEqual(sharedEnters, 1);
+        assert.strictEqual(leafEnters, 1);
+      });
+    });
+
+    context("given false / omitted ('never')", function () {
+      specify('should visit every occurrence and descend each time', function () {
+        const { root, shared } = buildDag();
+        let sharedEnters = 0;
+        let leafEnters = 0;
+
+        traverse(root, {
+          ObjectElement(path: Path) {
+            if (path.node === shared) {
+              sharedEnters += 1;
+            }
+          },
+          StringElement(path: Path) {
+            if ((path.node as StringElement).toValue() === 'leaf') {
+              leafEnters += 1;
+            }
+          },
+        });
+
+        // both occurrences of the shared node are visited and descended into
+        assert.strictEqual(sharedEnters, 2);
+        assert.strictEqual(leafEnters, 2);
+      });
+    });
+  });
+
   context('state injection', function () {
     specify('should inject state into visitor', function () {
       const root = new StringElement('test');

--- a/packages/apidom-traverse/test/traversal.ts
+++ b/packages/apidom-traverse/test/traversal.ts
@@ -383,11 +383,13 @@ describe('traverse', function () {
         const { root, shared } = buildDag();
         let sharedEnters = 0;
         let leafEnters = 0;
+        const revisitedFlags: boolean[] = [];
 
         traverse(
           root,
           {
             ObjectElement(path: Path) {
+              revisitedFlags.push(path.revisited);
               if (path.node === shared) {
                 sharedEnters += 1;
               }
@@ -398,13 +400,15 @@ describe('traverse', function () {
               }
             },
           },
-          // legacy boolean accepted at runtime for backward compatibility
-          { skipVisited: true as unknown as 'skip' },
+          // @ts-expect-error legacy boolean accepted at runtime for backward compatibility
+          { skipVisited: true },
         );
 
         // shared node entered once, never revisited
         assert.strictEqual(sharedEnters, 1);
         assert.strictEqual(leafEnters, 1);
+        // revisited is inert outside 'enter-only'
+        assert.isTrue(revisitedFlags.every((r) => r === false));
       });
     });
 
@@ -413,9 +417,11 @@ describe('traverse', function () {
         const { root, shared } = buildDag();
         let sharedEnters = 0;
         let leafEnters = 0;
+        const revisitedFlags: boolean[] = [];
 
         traverse(root, {
           ObjectElement(path: Path) {
+            revisitedFlags.push(path.revisited);
             if (path.node === shared) {
               sharedEnters += 1;
             }
@@ -430,6 +436,31 @@ describe('traverse', function () {
         // both occurrences of the shared node are visited and descended into
         assert.strictEqual(sharedEnters, 2);
         assert.strictEqual(leafEnters, 2);
+        // revisited is inert outside 'enter-only'
+        assert.isTrue(revisitedFlags.every((r) => r === false));
+      });
+    });
+
+    context('given false explicitly', function () {
+      specify('should map to never (legacy boolean back-compat)', function () {
+        const { root, shared } = buildDag();
+        let sharedEnters = 0;
+
+        traverse(
+          root,
+          {
+            ObjectElement(path: Path) {
+              if (path.node === shared) {
+                sharedEnters += 1;
+              }
+            },
+          },
+          // @ts-expect-error legacy boolean accepted at runtime for backward compatibility
+          { skipVisited: false },
+        );
+
+        // false behaves as 'never' — both occurrences visited
+        assert.strictEqual(sharedEnters, 2);
       });
     });
   });


### PR DESCRIPTION
## Summary

Upstream changes in `apidom-traverse` required by [jentic-apitools#155](https://github.com/jentic/jentic-apitools/pull/155). Consumer plugins (`max-schema-depth`, `resolved-refs`) need to observe every occurrence of a shared node in a dereferenced DAG without paying the combinatorial-explosion cost of re-descending into the already-walked subtree.

### tri-state `skipVisited`
`skipVisited` is now `SkipVisitedMode` (`'never' | 'skip' | 'enter-only'`):
- `'never'` — no skipping (default)
- `'skip'` — skip the node entirely on re-encounter (no enter/leave, no descent)
- `'enter-only'` — re-fire enter/leave on re-encounter but **don't re-descend** into the already-walked subtree

Legacy booleans are still accepted at runtime for backward compatibility (`false` → `'never'`, `true` → `'skip'`) via `normalizeSkipVisited`, but the public type now advertises only the string union. First-party callers (reference dereference strategies, core dispatcher test) migrated to `'skip'`.

### `path.revisited`
New public `path.revisited` field — `true` on non-descending revisits, set symmetrically on both **enter** and **leave** (carried via the node's stack frame). Propagated through the merged-visitor proxy. `SkipVisitedMode` is exported from the package.

## Tests
DAG fixture under `'enter-only'` asserts enter/leave fire on both encounters, `revisited` is `false`→`true` on both enter and leave, children walked once, no leak; plus `'skip'`/`'never'` keep `revisited` inert, and explicit `true`/`false` legacy-boolean back-compat.

## Verification
- `tsc --noEmit` (all 38 packages): clean
- `apidom-traverse`: 141 passing · `apidom-core`: 1166 · `apidom-reference`: 1166
- `lint`: 0 errors

## Note on circular `ref-type`
The reference-side change (annotating circular `circular: 'replace'` replacements with `ref-type` meta) was dropped: a circular replacement is already a `RefElement` (`element === 'ref'`) carrying its `type` in meta, so it self-identifies as a reference. Consumers detect circular refs via `isRefElement` rather than needing an extra `ref-type` annotation — no apidom change required.
