### PR TITLE
fix(datamodel): register annotation, comment and parseResult elements

### DIFF
--- a/packages/apidom-datamodel/src/Namespace.ts
+++ b/packages/apidom-datamodel/src/Namespace.ts
@@ -113,7 +113,10 @@ class Namespace {
       .register('member', elements.MemberElement)
       .register('ref', elements.RefElement)
       .register('link', elements.LinkElement)
-      .register('sourceMap', elements.SourceMapElement);
+      .register('sourceMap', elements.SourceMapElement)
+      .register('annotation', elements.AnnotationElement)
+      .register('comment', elements.CommentElement)
+      .register('parseResult', elements.ParseResultElement);
 
     // Add instance detection functions to convert existing objects into
     // the corresponding refract elements.

--- a/packages/apidom-datamodel/test/Namespace.ts
+++ b/packages/apidom-datamodel/test/Namespace.ts
@@ -1,5 +1,13 @@
 import { assert } from 'chai';
-import { Namespace, JSONSerialiser, StringElement, Element } from '../src/index.ts';
+import {
+  Namespace,
+  JSONSerialiser,
+  StringElement,
+  Element,
+  AnnotationElement,
+  CommentElement,
+  ParseResultElement,
+} from '../src/index.ts';
 
 describe('Namespace', function () {
   let namespace: Namespace;
@@ -35,6 +43,12 @@ describe('Namespace', function () {
       const testnamespace = new Namespace({ noDefault: true });
       testnamespace.useDefault();
       assert.isNotEmpty(testnamespace.elementMap);
+    });
+
+    specify('register annotation, comment and parseResult elements', function () {
+      assert.strictEqual(namespace.getElementClass('annotation'), AnnotationElement);
+      assert.strictEqual(namespace.getElementClass('comment'), CommentElement);
+      assert.strictEqual(namespace.getElementClass('parseResult'), ParseResultElement);
     });
   });
 


### PR DESCRIPTION
## Summary

The datamodel extraction (#11) moved default element registration from `apidom-core`'s namespace into datamodel's `Namespace#useDefault()`, but dropped three registrations that existed before: `annotation`, `comment`, and `parseResult`. Only `sourceMap` survived.

As a result, deserialising refract JSON via `fromRefract()` fell back to the base `Element` class for these element types. A round-tripped `parseResult` element therefore lost its `.api` getter and collection behavior (`.length`, `.filter`, etc.).

This surfaced in the playground's **Dereference** screen: the worker does `from(apiDOM, namespace).api` and passes it to `dereferenceApiDOM`, which calls `cloneShallow` on the now-`undefined` `.api` and throws:

```
ShallowCloneError: Value provided to cloneShallow function couldn't be cloned
    at cloneShallow (.../apidom-datamodel/src/clone/index.mjs)
    at dereferenceApiDOM (.../apidom-reference/src/dereference/index.mjs)
```

## Fix

Restore the three missing registrations in `useDefault()`.

## Testing

Added a regression test asserting `annotation`, `comment`, and `parseResult` resolve to their concrete element classes (not the base `Element` fallback). Full datamodel suite passes (400 tests).