### PR TITLE
fix(playground): migrate to MUI v9 component APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6857,6 +6857,225 @@
         "resolve": "~1.22.2"
       }
     },
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.1.2.tgz",
+      "integrity": "sha512-ZMufoA/YFOEVp48lskcAOTlQYwpdBk4Z++4yUgPDEfuLHIpxBx9g+urGmIBKOtr+7M0ZlYfCxSvrJpEE/S32sg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.1.2.tgz",
+      "integrity": "sha512-CN2U1etAL+6qZT2XjJR1Ibv7nyE2wBN3/28b5XpXjQFMtBKNlD45wQupODfJrm9PLanJ1DefocHWIQZ5PkSipQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/core-downloads-tracker": "^9.1.2",
+        "@mui/system": "^9.1.2",
+        "@mui/types": "^9.1.1",
+        "@mui/utils": "^9.1.1",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.6",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^9.1.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT"
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.1.1.tgz",
+      "integrity": "sha512-oH6c+d6sJ1CZT0Vg2/fHdUQ5zvo9Pn+f+WWk0tlQliHqqIRdN32DZ7UxjalW3LUj4OkHbdWR31biWuLxK9i7Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/utils": "^9.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.1.1.tgz",
+      "integrity": "sha512-neaYKdJfvEG54q8efHLJR7swpHG/gfSv9xGqW5iTSMsubD7yPCPFrhVBt284j1DOF3uZaaDJSHQL7gz6jGF21Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.1.2.tgz",
+      "integrity": "sha512-oJxyyummOR6nV8ODF/yugasJ//pSsQxxfYCE9q9RU2Hef0f5RRzJ75M9zr5NvHDhzhGgrPstkaNrJtmcuz/Pdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/private-theming": "^9.1.1",
+        "@mui/styled-engine": "^9.1.1",
+        "@mui/types": "^9.1.1",
+        "@mui/utils": "^9.1.1",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.1.1.tgz",
+      "integrity": "sha512-Zjt7u8wNvDg40rPTGoL+TnfkpuSKjwubsNSFRH1KAVZLcaV4I3AFNHIFbvH7p4F3alEibSbdd90xAgn5Rnfndg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.1.1.tgz",
+      "integrity": "sha512-qSNfnkzZMptaaWFFklpDf4NPJztgwsMDVfM/sSDt+wq4ssYSBhLYwwjuB6eS/+p2IUYbeRzHluzXbw0Zn7aI4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.1.1",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
@@ -26823,7 +27042,7 @@
         "@emotion/react": "=11.14.0",
         "@emotion/styled": "=11.14.1",
         "@mui/icons-material": "^9.1.1",
-        "@mui/material": "^9.1.1",
+        "@mui/material": "^9.1.2",
         "@speclynx/apidom-core": "*",
         "@speclynx/apidom-datamodel": "*",
         "@speclynx/apidom-ns-arazzo-1": "*",
@@ -26863,16 +27082,6 @@
         "vite": "^8.0.16"
       }
     },
-    "packages/apidom-playground/node_modules/@mui/core-downloads-tracker": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.1.1.tgz",
-      "integrity": "sha512-AupmMICbdJHqAh6FfOMaaiiIr7dfEgZJn5DFfiPuGNrbs+ZZy9cD1APwO0TSVBz5j08MJEEY6n7iC76/2wjMEA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      }
-    },
     "packages/apidom-playground/node_modules/@mui/icons-material": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.1.1.tgz",
@@ -26898,209 +27107,6 @@
           "optional": true
         }
       }
-    },
-    "packages/apidom-playground/node_modules/@mui/material": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.1.1.tgz",
-      "integrity": "sha512-Wv+gInjrpf99l1Q0oHe0eOWGTnlbkzs5nowClX65KCT/2fyPMwcbFEEkUsOHdpcHhB5UAbz/d7jlwt5ajWVvlA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@mui/core-downloads-tracker": "^9.1.1",
-        "@mui/system": "^9.1.1",
-        "@mui/types": "^9.1.1",
-        "@mui/utils": "^9.1.1",
-        "@popperjs/core": "^2.11.8",
-        "@types/react-transition-group": "^4.4.12",
-        "clsx": "^2.1.1",
-        "csstype": "^3.2.3",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.2.6",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^9.1.1",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@mui/material-pigment-css": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "packages/apidom-playground/node_modules/@mui/material/node_modules/@mui/system": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.1.1.tgz",
-      "integrity": "sha512-q+aqNa58QZUwmmyUvJKKrStrej+4BcWFw4M0Ug+zRylPIQgR64cqvBnE3QTfLZm4OXulydp8Hl3zwKxMayrdsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@mui/private-theming": "^9.1.1",
-        "@mui/styled-engine": "^9.1.1",
-        "@mui/types": "^9.1.1",
-        "@mui/utils": "^9.1.1",
-        "clsx": "^2.1.1",
-        "csstype": "^3.2.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "packages/apidom-playground/node_modules/@mui/material/node_modules/@mui/system/node_modules/@mui/private-theming": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.1.1.tgz",
-      "integrity": "sha512-oH6c+d6sJ1CZT0Vg2/fHdUQ5zvo9Pn+f+WWk0tlQliHqqIRdN32DZ7UxjalW3LUj4OkHbdWR31biWuLxK9i7Cg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@mui/utils": "^9.1.1",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "packages/apidom-playground/node_modules/@mui/material/node_modules/@mui/system/node_modules/@mui/styled-engine": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.1.1.tgz",
-      "integrity": "sha512-neaYKdJfvEG54q8efHLJR7swpHG/gfSv9xGqW5iTSMsubD7yPCPFrhVBt284j1DOF3uZaaDJSHQL7gz6jGF21Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/sheet": "^1.4.0",
-        "csstype": "^3.2.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
-      }
-    },
-    "packages/apidom-playground/node_modules/@mui/material/node_modules/@mui/utils": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.1.1.tgz",
-      "integrity": "sha512-qSNfnkzZMptaaWFFklpDf4NPJztgwsMDVfM/sSDt+wq4ssYSBhLYwwjuB6eS/+p2IUYbeRzHluzXbw0Zn7aI4A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@mui/types": "^9.1.1",
-        "@types/prop-types": "^15.7.15",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.2.6"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "packages/apidom-playground/node_modules/@mui/types": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.1.1.tgz",
-      "integrity": "sha512-Zjt7u8wNvDg40rPTGoL+TnfkpuSKjwubsNSFRH1KAVZLcaV4I3AFNHIFbvH7p4F3alEibSbdd90xAgn5Rnfndg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "packages/apidom-playground/node_modules/react-is": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-      "license": "MIT"
     },
     "packages/apidom-reference": {
       "name": "@speclynx/apidom-reference",

--- a/packages/apidom-playground/package.json
+++ b/packages/apidom-playground/package.json
@@ -26,7 +26,7 @@
     "@emotion/react": "=11.14.0",
     "@emotion/styled": "=11.14.1",
     "@mui/icons-material": "^9.1.1",
-    "@mui/material": "^9.1.1",
+    "@mui/material": "^9.1.2",
     "@speclynx/apidom-core": "*",
     "@speclynx/apidom-datamodel": "*",
     "@speclynx/apidom-ns-arazzo-1": "*",

--- a/packages/apidom-playground/src/playground/components/DereferenceDialog.jsx
+++ b/packages/apidom-playground/src/playground/components/DereferenceDialog.jsx
@@ -57,7 +57,7 @@ const ApiDOMInterpreterDialog = ({ open, onClose }) => {
       open={open}
       onClose={onClose}
       aria-labelledby="form-dialog-title"
-      TransitionComponent={Transition}
+      slots={{ transition: Transition }}
     >
       <AppBar>
         <Toolbar>
@@ -82,7 +82,7 @@ const ApiDOMInterpreterDialog = ({ open, onClose }) => {
           />
         </FormControl>
         <Box mt={2}>
-          <Grid container justifyContent="center">
+          <Grid container sx={{ justifyContent: 'center' }}>
             <ButtonGroup
               variant="contained"
               color="primary"

--- a/packages/apidom-playground/src/playground/components/importer/FileImporter.jsx
+++ b/packages/apidom-playground/src/playground/components/importer/FileImporter.jsx
@@ -79,13 +79,13 @@ const FileImporter = () => {
         <SpeedDialAction
           key="Import URL"
           icon={<ImportExportIcon />}
-          tooltipTitle="Import URL"
+          slotProps={{ tooltip: { title: 'Import URL' } }}
           onClick={handleUrlDialogOpen}
         />
         <SpeedDialAction
           key="Attach file"
           icon={<AttachFileIcon />}
-          tooltipTitle="Attach file"
+          slotProps={{ tooltip: { title: 'Attach file' } }}
           onClick={handleFileUploadClick}
         />
       </SpeedDial>

--- a/packages/apidom-playground/src/playground/components/left-pane/Editor.jsx
+++ b/packages/apidom-playground/src/playground/components/left-pane/Editor.jsx
@@ -15,22 +15,18 @@ const Editor = ({ className }) => {
   return (
     <div className={className}>
       <FormControl fullWidth>
-        <OutlinedInput // currently not showing scroll bar due to https://github.com/swagger-api/apidom/issues/4027
+        <OutlinedInput
           fullWidth
           multiline
           id="input"
-          sx={{
-            '.MuiInputBase-inputMultiline': {
-              height: 'calc(100vh - 64px - 190px - 80px)',
-              maxHeight: 'calc(100vh - 64px - 190px - 80px)',
-              display: 'block',
-            },
-          }}
+          inputComponent="textarea"
           value={source}
           onChange={handleEditorChange}
           inputProps={{
             style: {
               height: 'calc(100vh - 64px - 190px - 80px)',
+              maxHeight: 'calc(100vh - 64px - 190px - 80px)',
+              overflow: 'auto',
             },
           }}
         />

--- a/packages/apidom-playground/src/playground/components/left-pane/EditorControls.jsx
+++ b/packages/apidom-playground/src/playground/components/left-pane/EditorControls.jsx
@@ -106,9 +106,11 @@ const EditorControls = () => {
       <Grid
         container
         direction="row"
-        justifyContent="center"
-        alignItems="center"
-        sx={{ marginTop: (theme) => theme.spacing(2) }}
+        sx={{
+          justifyContent: 'center',
+          alignItems: 'center',
+          marginTop: (theme) => theme.spacing(2),
+        }}
       >
         <Grid>
           <ButtonGroup

--- a/packages/apidom-playground/src/playground/components/right-pane/ApiDOMInterpreterDialog.jsx
+++ b/packages/apidom-playground/src/playground/components/right-pane/ApiDOMInterpreterDialog.jsx
@@ -39,7 +39,7 @@ const ApiDOMInterpreterDialog = ({ open, onClose }) => {
       open={open}
       onClose={onClose}
       aria-labelledby="form-dialog-title"
-      TransitionComponent={Transition}
+      slots={{ transition: Transition }}
     >
       <AppBar>
         <Toolbar>

--- a/packages/apidom-playground/src/playground/components/right-pane/Console.jsx
+++ b/packages/apidom-playground/src/playground/components/right-pane/Console.jsx
@@ -36,16 +36,18 @@ const Console = () => {
         variant="outlined"
         value={consoleContent}
         inputRef={inputRef}
-        InputProps={{
-          readOnly: true,
-          sx: (theme) => ({
-            height: 190.5,
-            ...theme.typography.caption,
-            marginBottom: 0,
-          }),
-        }}
-        InputLabelProps={{
-          shrink: true,
+        slotProps={{
+          input: {
+            readOnly: true,
+            sx: (theme) => ({
+              height: 190.5,
+              ...theme.typography.caption,
+              marginBottom: 0,
+            }),
+          },
+          inputLabel: {
+            shrink: true,
+          },
         }}
       />
       <Tooltip title="Clear console">


### PR DESCRIPTION
Closes #349

## Summary

The `@mui/material` v7 → v9 upgrade (#340) removed/renamed a batch of props the playground still used. Each removed prop silently leaked onto the underlying DOM element (the React "does not recognize the X prop" warnings) and its associated styling/behavior stopped working — most visibly the editor textarea and the dialogs.

## Changes (MUI v9 API migrations)

| Component | Before (≤ v7) | After (v9) |
|-----------|---------------|------------|
| `Editor` `OutlinedInput` | `sx` targeting non-existent `.MuiInputBase-inputMultiline` + autosizing | `inputComponent="textarea"` + inline `maxHeight`/`overflow` → **scrolls instead of growing** |
| `Console` `TextField` | `InputProps` / `InputLabelProps` | `slotProps={{ input, inputLabel }}` |
| `DereferenceDialog` / `ApiDOMInterpreterDialog` `Dialog` | `TransitionComponent` | `slots={{ transition }}` |
| `FileImporter` `SpeedDialAction` | `tooltipTitle` | `slotProps={{ tooltip: { title } }}` |
| `EditorControls` / `DereferenceDialog` `Grid` | `justifyContent` / `alignItems` props | moved into `sx` |

Also bumps `@mui/material` `^9.1.1` → `^9.1.2`.

## Notes

- The textarea growth fix resolves the long-standing scrollbar issue (the `OutlinedInput` comment previously pointed at the original tracking issue).
- This PR depends on #356 for the **Dereference** screen to fully function — that fixes a separate `apidom-datamodel` regression (`cloneShallow` / `ShallowCloneError`). The playground prop migrations here and the datamodel fix there are independent and split per the repo's small-PR convention.

## Testing

- `npm run build` and `eslint` pass.
- Dev server runs; verified the editor scrolls, dialogs open, and the prop warnings are cleared.