### PR TITLE
chore(harness): document DCO sign-off requirement

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -9,6 +9,7 @@
 - Reference related issues with `Refs #<issue>` in the commit body.
 - Do NOT use GitHub magic close-keywords (`Closes`, `Fixes`, `Resolves`) in commit messages — those belong in the PR body so they close issues on merge, not on every push.
 - Follow Conventional Commits (see `conventional-commits.md`).
+- Sign off every commit with DCO: `git commit -s` (per `CONTRIBUTING.md`).
 
 ## Issues
 


### PR DESCRIPTION
## Summary

- Adds a line to `.claude/rules/git-workflow.md`'s Commits section noting that commits must be signed off (`git commit -s`) per the DCO requirement already stated in `CONTRIBUTING.md`
- The Claude Code harness rules didn't mention this, so a recent harness-authored commit (#358) initially omitted the `Signed-off-by` trailer

## Test plan

- [x] N/A — documentation-only change to `.claude/rules/`