### PR TITLE
feat(reference): add Arazzo 1 bundle strategy

### DIFF
--- a/packages/apidom-reference/README.md
+++ b/packages/apidom-reference/README.md
@@ -2925,6 +2925,59 @@ await bundle('/home/user/oas.json', {
 Hoisted components and embedded schema resources are annotated with a `ref-origin` meta field pointing at
 their source document. The bundling process is **immutable** by default (`bundle.immutable: true`).
 
+##### [arazzo-1](https://github.com/speclynx/apidom/tree/main/packages/apidom-reference/src/bundle/strategies/arazzo-1)
+
+Bundle strategy for bundling [Arazzo 1.x](https://spec.openapis.org/arazzo/latest.html) definitions.
+
+The only external references Arazzo defines are **JSON Schema Objects** — a
+[JSON Schema 2020-12](https://json-schema.org/draft/2020-12) dialect used by Input Objects and inline schemas.
+(Reusable Objects are internal-only runtime-expression references, and Source Descriptions point at whole
+external documents that are intentionally kept external — neither is bundled.) Schema Objects are therefore
+bundled per the [JSON Schema Compound Document](https://json-schema.org/blog/posts/bundling-json-schema-compound-documents)
+rules, exactly as in the `openapi-3-1` strategy: the external schema **resource** is embedded verbatim into
+`components.inputs` carrying its `$id` (one is assigned from the retrieval URI when absent), and the referencing
+`$ref` is left **unchanged** — it keeps resolving against the embedded resource's `$id`. The whole external
+resource is embedded once, keyed by its `$id`; references (including `$anchor`, `$dynamicRef`, and
+`$dynamicAnchor`) are never rewritten. Nested external schema resources are embedded flat into the top-level
+`components.inputs`, deduplicated by resource URI. Internal Schema Object references are preserved untouched.
+
+Supported media types:
+
+```js
+[
+  'application/vnd.oai.workflows;version=1.0.0',
+  'application/vnd.oai.workflows+json;version=1.0.0',
+  'application/vnd.oai.workflows+yaml;version=1.0.0',
+  'application/vnd.oai.workflows;version=1.0.1',
+  'application/vnd.oai.workflows+json;version=1.0.1',
+  'application/vnd.oai.workflows+yaml;version=1.0.1'
+]
+```
+
+This strategy's behavior is controlled by the same `bundle` options as the `openapi-3-1` strategy
+(`componentNamesStrategy`, `onComponentNameCollision`, `immutable`, `maxDepth`, `continueOnError`, `refSet`),
+documented above. Per-strategy overrides use the `arazzo-1` key in `bundle.strategyOpts`:
+
+```js
+import { bundle } from '@speclynx/apidom-reference';
+
+await bundle('/home/user/arazzo.json', {
+  parse: {
+    mediaType: 'application/vnd.oai.workflows+json;version=1.0.1',
+  },
+  bundle: {
+    strategyOpts: {
+      'arazzo-1': {
+        onComponentNameCollision: 'error',
+      },
+    },
+  },
+});
+```
+
+Embedded schema resources are annotated with a `ref-origin` meta field pointing at their source document.
+The bundling process is **immutable** by default (`bundle.immutable: true`).
+
 ##### Bundle strategies execution order
 
 It's important to understand that default bundle strategies are run in specific order. The order is determined
@@ -2940,6 +2993,7 @@ returns `true` or until entire list of strategies is exhausted (throws error).
   new OpenAPI2BundleStrategy(),
   new OpenAPI3_0BundleStrategy(),
   new OpenAPI3_1BundleStrategy(),
+  new Arazzo1BundleStrategy(),
 ]
 ```
 Most specific strategies are listed first, most generic are listed last.

--- a/packages/apidom-reference/package.json
+++ b/packages/apidom-reference/package.json
@@ -263,6 +263,11 @@
       "import": "./src/bundle/strategies/openapi-3-1/index.mjs",
       "require": "./src/bundle/strategies/openapi-3-1/index.cjs",
       "types": "./types/bundle/strategies/openapi-3-1/index.d.ts"
+    },
+    "./bundle/strategies/arazzo-1": {
+      "import": "./src/bundle/strategies/arazzo-1/index.mjs",
+      "require": "./src/bundle/strategies/arazzo-1/index.cjs",
+      "types": "./types/bundle/strategies/arazzo-1/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/apidom-reference/src/bundle/strategies/arazzo-1/index.ts
+++ b/packages/apidom-reference/src/bundle/strategies/arazzo-1/index.ts
@@ -1,0 +1,117 @@
+import { ParseResultElement, cloneDeep } from '@speclynx/apidom-datamodel';
+import { traverseAsync } from '@speclynx/apidom-traverse';
+import { mediaTypes, isArazzoSpecification1Element } from '@speclynx/apidom-ns-arazzo-1';
+
+import File from '../../../File.ts';
+import Reference from '../../../Reference.ts';
+import ReferenceSet from '../../../ReferenceSet.ts';
+import BundleStrategy, { BundleStrategyOptions } from '../BundleStrategy.ts';
+import Arazzo1BundleVisitor from './visitor.ts';
+import type { ReferenceOptions } from '../../../options/index.ts';
+
+export type {
+  default as DereferenceStrategy,
+  DereferenceStrategyOptions,
+} from '../../../dereference/strategies/DereferenceStrategy.ts';
+export type { default as File, FileOptions } from '../../../File.ts';
+export type { default as Reference, ReferenceOptions } from '../../../Reference.ts';
+export type { default as ReferenceSet, ReferenceSetOptions } from '../../../ReferenceSet.ts';
+export type { Arazzo1BundleVisitorOptions } from './visitor.ts';
+export type {
+  ReferenceOptions as ApiDOMReferenceOptions,
+  ReferenceBundleOptions as ApiDOMReferenceBundleOptions,
+  ReferenceDereferenceOptions as ApiDOMReferenceDereferenceOptions,
+  ReferenceParseOptions as ApiDOMReferenceParseOptions,
+  ReferenceResolveOptions as ApiDOMReferenceResolveOptions,
+} from '../../../options/index.ts';
+export type { default as Parser, ParserOptions } from '../../../parse/parsers/Parser.ts';
+export type { default as Resolver, ResolverOptions } from '../../../resolve/resolvers/Resolver.ts';
+export type {
+  default as ResolveStrategy,
+  ResolveStrategyOptions,
+} from '../../../resolve/strategies/ResolveStrategy.ts';
+export type { default as BundleStrategy, BundleStrategyOptions } from '../BundleStrategy.ts';
+
+export type {
+  ComponentNamesStrategy,
+  ComponentNameResolver,
+  ComponentNameResolverArgs,
+  ComponentNameCollisionSeverity,
+} from '../../../options/index.ts';
+
+/**
+ * @public
+ */
+export interface Arazzo1BundleStrategyOptions extends Omit<BundleStrategyOptions, 'name'> {}
+
+/**
+ * @public
+ */
+class Arazzo1BundleStrategy extends BundleStrategy {
+  constructor(options?: Arazzo1BundleStrategyOptions) {
+    super({ ...(options ?? {}), name: 'arazzo-1' });
+  }
+
+  canBundle(file: File): boolean {
+    // assert by media type
+    if (file.mediaType !== 'text/plain') {
+      return mediaTypes.includes(file.mediaType);
+    }
+
+    // assert by inspecting ApiDOM
+    return isArazzoSpecification1Element(file.parseResult?.result);
+  }
+
+  async bundle(file: File, options: ReferenceOptions): Promise<ParseResultElement> {
+    const immutableRefSet = options.bundle.refSet ?? new ReferenceSet();
+    const mutableRefSet = new ReferenceSet();
+    let refSet = immutableRefSet;
+    let reference;
+
+    // determine the initial reference
+    if (!immutableRefSet.has(file.uri)) {
+      reference = new Reference({ uri: file.uri, value: file.parseResult! });
+      immutableRefSet.add(reference);
+    } else {
+      // pre-computed refSet was provided as configuration option
+      reference = immutableRefSet.find((ref) => ref.uri === file.uri);
+    }
+
+    /**
+     * Clone refSet due the bundling process being mutable.
+     * We don't want to mutate the original refSet and the references.
+     */
+    if (options.bundle.immutable) {
+      immutableRefSet.refs
+        .map((ref) => new Reference({ ...ref, value: cloneDeep(ref.value) }))
+        .forEach((ref) => mutableRefSet.add(ref));
+      reference = mutableRefSet.find((ref) => ref.uri === file.uri);
+      refSet = mutableRefSet;
+    }
+
+    const visitor = new Arazzo1BundleVisitor({
+      reference: reference!,
+      options,
+    });
+    await traverseAsync(refSet.rootRef!.value, visitor, {
+      mutable: true,
+    });
+
+    const parseResult = reference!.value as ParseResultElement;
+
+    /**
+     * Release all memory if this refSet was not provided as a configuration option.
+     * If provided as configuration option, then provider is responsible for cleanup.
+     */
+    if (options.bundle.refSet === null) {
+      immutableRefSet.clean();
+    }
+
+    mutableRefSet.clean();
+
+    return parseResult;
+  }
+}
+
+export { Arazzo1BundleVisitor };
+export default Arazzo1BundleStrategy;

--- a/packages/apidom-reference/src/bundle/strategies/arazzo-1/visitor.ts
+++ b/packages/apidom-reference/src/bundle/strategies/arazzo-1/visitor.ts
@@ -1,0 +1,484 @@
+import { none } from 'ramda';
+import {
+  isElement,
+  isObjectElement,
+  isStringElement,
+  Element,
+  ObjectElement,
+  ParseResultElement,
+  AnnotationElement,
+  cloneDeep,
+} from '@speclynx/apidom-datamodel';
+import { toValue, toYAML, fixedFields } from '@speclynx/apidom-core';
+import { traverseAsync, type Path } from '@speclynx/apidom-traverse';
+import {
+  evaluate as jsonPointerEvaluate,
+  escape,
+  URIFragmentIdentifier,
+} from '@speclynx/apidom-json-pointer';
+import {
+  JSONSchemaElement,
+  ComponentsElement,
+  ComponentsInputsElement,
+  ArazzoSpecification1Element,
+} from '@speclynx/apidom-ns-arazzo-1';
+
+import BundleError from '../../../errors/BundleError.ts';
+import UnresolvableReferenceError from '../../../errors/UnresolvableReferenceError.ts';
+import MaximumBundleDepthError from '../../../errors/MaximumBundleDepthError.ts';
+import MaximumResolveDepthError from '../../../errors/MaximumResolveDepthError.ts';
+import EvaluationJsonSchemaUriError from '../../../errors/EvaluationJsonSchemaUriError.ts';
+import * as url from '../../../util/url.ts';
+import parse from '../../../parse/index.ts';
+import Reference from '../../../Reference.ts';
+import ReferenceSet from '../../../ReferenceSet.ts';
+import File from '../../../File.ts';
+import Resolver from '../../../resolve/resolvers/Resolver.ts';
+import {
+  isAnchor,
+  uriToAnchor,
+  evaluate as $anchorEvaluate,
+} from '../../../dereference/strategies/arazzo-1/selectors/$anchor.ts';
+import { evaluate as uriEvaluate } from '../../../dereference/strategies/arazzo-1/selectors/uri.ts';
+import {
+  resolveSchema$refField,
+  resolveSchema$idField,
+  maybeRefractToJSONSchemaElement,
+} from '../../../dereference/strategies/arazzo-1/util.ts';
+import {
+  toPascalCase,
+  sanitizeComponentName,
+  uniqueName as resolveUniqueName,
+} from '../../util.ts';
+import type { ReferenceOptions } from '../../../options/index.ts';
+
+/**
+ * The Components Object field where embedded JSON Schema resources are hoisted.
+ * Sourced from the Components Object fixed fields so it cannot drift from the
+ * namespace definition.
+ */
+const cf = fixedFields(ComponentsElement, { indexed: true });
+
+/**
+ * @public
+ */
+export interface Arazzo1BundleVisitorOptions {
+  readonly reference: Reference;
+  readonly options: ReferenceOptions;
+  readonly assignments?: Map<string, string>;
+  readonly reservedNames?: Map<string, Set<string>>;
+}
+
+/**
+ * @public
+ */
+class Arazzo1BundleVisitor {
+  protected readonly reference: Reference;
+
+  protected readonly options: ReferenceOptions;
+
+  /**
+   * The entry parse result. Derived from the shared refSet's root reference.
+   */
+  protected get entryParseResult(): ParseResultElement {
+    return this.reference.refSet!.rootRef!.value as ParseResultElement;
+  }
+
+  /**
+   * The entry document element. Embedded external schema resources are placed
+   * into its `components.inputs` object. The `canBundle` guard guarantees it is
+   * an ArazzoSpecification1Element.
+   */
+  protected get entryResult(): ArazzoSpecification1Element {
+    return this.entryParseResult.result as ArazzoSpecification1Element;
+  }
+
+  /**
+   * Shared across the entry document and every external document visitor.
+   * Guarantees each external resource is embedded exactly once, keyed by its
+   * resource URI.
+   */
+  protected readonly assignments: Map<string, string>;
+
+  /**
+   * Component names already reserved per Components Object field. Reserved
+   * before recursion so collision suffixing (`Pet`, `Pet-2`, ...) accounts for
+   * components that are still being bundled.
+   */
+  protected readonly reservedNames: Map<string, Set<string>>;
+
+  constructor({
+    reference,
+    options,
+    assignments = new Map<string, string>(),
+    reservedNames = new Map<string, Set<string>>(),
+  }: Arazzo1BundleVisitorOptions) {
+    this.reference = reference;
+    this.options = options;
+    this.assignments = assignments;
+    this.reservedNames = reservedNames;
+  }
+
+  protected toBaseURI(uri: string): string {
+    return url.resolve(this.reference.uri, url.sanitize(url.stripHash(uri)));
+  }
+
+  protected async toReference(uri: string): Promise<Reference> {
+    // detect maximum depth of resolution
+    if (this.reference.depth >= this.options.resolve.maxDepth) {
+      throw new MaximumResolveDepthError(
+        `Maximum resolution depth of ${this.options.resolve.maxDepth} has been exceeded by file "${this.reference.uri}"`,
+        { maxDepth: this.options.resolve.maxDepth, uri: this.reference.uri },
+      );
+    }
+
+    const baseURI = this.toBaseURI(uri);
+    const { refSet } = this.reference as { refSet: ReferenceSet };
+
+    // we've already processed this Reference in past
+    if (refSet.has(baseURI)) {
+      return refSet.find((ref) => ref.uri === baseURI)!;
+    }
+
+    const parseResult = await parse(url.unsanitize(baseURI), {
+      ...this.options,
+      parse: { ...this.options.parse, mediaType: 'text/plain' },
+    });
+
+    const reference = new Reference({
+      uri: baseURI,
+      value: parseResult,
+      depth: this.reference.depth + 1,
+    });
+    refSet.add(reference);
+
+    return reference;
+  }
+
+  /**
+   * Handles an error according to the `bundle.continueOnError` option.
+   *
+   * For new errors: wraps in UnresolvableReferenceError with structured
+   * context. For errors already wrapped by a nested visitor: prepends the
+   * current hop to the trace.
+   *
+   * Inner/intermediate visitors always throw to let the trace accumulate. Only
+   * the entry document visitor respects continueOnError (callback/swallow/throw).
+   */
+  protected handleError(
+    message: string,
+    error: Error,
+    referencingElement: Element,
+    refFieldName: string,
+    refFieldValue: string,
+    visitorPath: Path<Element>,
+  ): void {
+    // a collision reported as `error` is a deliberate hard stop with no
+    // resolution-failure analog, so pass it through unchanged. A maxDepth
+    // breach (MaximumBundleDepthError, which also extends BundleError) is a
+    // resolution failure and flows through below — wrapped and subject to
+    // continueOnError, like dereferencing.
+    if (error instanceof BundleError && !(error instanceof MaximumBundleDepthError)) {
+      throw error;
+    }
+
+    const { continueOnError } = this.options.bundle;
+    const isEntryDocument =
+      url.stripHash(this.reference.refSet?.rootRef?.uri ?? '') === this.reference.uri;
+    const uri = this.reference.uri;
+    const type = referencingElement.element as string;
+    const codeFrame = toYAML(referencingElement);
+    const location = visitorPath.formatPath();
+    const hop = { uri, type, refFieldName, refFieldValue, location, codeFrame };
+
+    let unresolvedError: UnresolvableReferenceError;
+    if (error instanceof UnresolvableReferenceError) {
+      // @ts-ignore
+      error.trace = [hop, ...error.trace];
+      unresolvedError = error;
+    } else {
+      unresolvedError = new UnresolvableReferenceError(message, {
+        cause: error,
+        type,
+        uri,
+        location,
+        codeFrame,
+        refFieldName,
+        refFieldValue,
+        trace: [],
+      });
+    }
+
+    if (!isEntryDocument || continueOnError === false) throw unresolvedError;
+    if (typeof continueOnError === 'function') continueOnError(unresolvedError);
+  }
+
+  /**
+   * Lazily creates the Components Object (and the `inputs` field within it) on
+   * the entry document, returning the field where a resource is embedded.
+   */
+  protected ensureInputsField(): ObjectElement {
+    const entryResult = this.entryResult;
+    let components = entryResult.components;
+    if (!isObjectElement(components)) {
+      components = new ComponentsElement();
+      entryResult.components = components;
+    }
+
+    let inputs = components.get(cf.inputs.name) as ObjectElement | undefined;
+    if (!isObjectElement(inputs)) {
+      inputs = new ComponentsInputsElement();
+      components.set(cf.inputs.name, inputs);
+    }
+
+    return inputs;
+  }
+
+  /**
+   * Computes the base component name (before collision suffixing) according to
+   * the configured naming strategy.
+   */
+  protected baseName(element: Element, baseURI: string): string {
+    // strategy specific options take precedence over the top-level bundle options
+    const componentNamesStrategy =
+      this.options.bundle.strategyOpts['arazzo-1']?.componentNamesStrategy ??
+      this.options.bundle.componentNamesStrategy;
+
+    const fallback = url.getBasename(baseURI) || 'Schema';
+
+    if (typeof componentNamesStrategy === 'function') {
+      const resolved = componentNamesStrategy({
+        element,
+        field: cf.inputs.name,
+        jsonPointer: '',
+        baseURI,
+      });
+      if (typeof resolved === 'string' && resolved !== '') {
+        return resolved;
+      }
+      return fallback;
+    }
+
+    if (componentNamesStrategy === 'title') {
+      const title = isObjectElement(element) ? toValue(element.get('title')) : undefined;
+      if (typeof title === 'string' && title.trim() !== '') {
+        const name = sanitizeComponentName(toPascalCase(title));
+        if (name !== '') return name;
+      }
+      // fall back to basename when no usable title is present
+    }
+
+    return fallback;
+  }
+
+  /**
+   * Computes a collision-free component name within `components.inputs`. A name
+   * is taken if it's already placed in inputs or reserved by a component that is
+   * still being bundled (reserved before recursion).
+   */
+  protected uniqueName(candidate: string): string {
+    const field = cf.inputs.name;
+    const inputs = this.ensureInputsField();
+    const reserved = this.reservedNames.get(field) ?? new Set<string>();
+    return resolveUniqueName(candidate, (name) => inputs.hasKey(name) || reserved.has(name));
+  }
+
+  /**
+   * Reports a collision-forced rename according to the configured severity.
+   * A rename means two distinct targets resolved to the same name; each keeps
+   * its own component (and origin), so report the rename per severity.
+   */
+  protected reportNameCollision(preferredName: string, componentName: string): void {
+    // strategy specific options take precedence over the top-level bundle options
+    const onComponentNameCollision =
+      this.options.bundle.strategyOpts['arazzo-1']?.onComponentNameCollision ??
+      this.options.bundle.onComponentNameCollision;
+    if (componentName === preferredName || onComponentNameCollision === 'off') {
+      return;
+    }
+
+    const message = `Component "${preferredName}" in components/${cf.inputs.name} is referenced with the same name but different content. Renamed to "${componentName}".`;
+    if (onComponentNameCollision === 'error') {
+      throw new BundleError(message);
+    }
+    const annotation = new AnnotationElement(message);
+    annotation.classes.push('warning');
+    annotation.code = 'bundle-component-name-collision';
+    // append (never prepend) so the result element stays ahead of annotations
+    (this.entryParseResult.content as Element[]).push(annotation);
+  }
+
+  /**
+   * JSON Schema Objects in Arazzo (used by Input Objects and inline schemas) are
+   * a JSON Schema 2020-12 dialect — the only external reference type Arazzo
+   * defines. They are bundled per the JSON Schema Compound Document rules: the
+   * external schema RESOURCE is embedded verbatim into `components.inputs`
+   * (carrying its `$id`), and the referencing `$ref` is left UNCHANGED — it
+   * keeps resolving against the embedded resource's `$id`. This mirrors the
+   * openapi-3-1 strategy's Schema Object handling.
+   */
+  public async JSONSchemaElement(path: Path<Element>) {
+    const referencingElement = path.node as JSONSchemaElement;
+
+    // skip current referencing schema as $ref keyword was not defined
+    if (!isStringElement(referencingElement.$ref)) {
+      return;
+    }
+
+    const $ref = toValue(referencingElement.$ref) as string;
+
+    try {
+      // compute baseURI using rules around $id and $ref keywords. The current
+      // document's URI is the retrieval URI — derive it directly (not via
+      // toReference) so an internal $ref needs no resolution and never trips the
+      // resolve.maxDepth guard.
+      const retrievalURI = this.reference.uri;
+      const $refBaseURI = resolveSchema$refField(retrievalURI, referencingElement)!;
+      const $refBaseURIStrippedHash = url.stripHash($refBaseURI);
+      const file = new File({ uri: $refBaseURIStrippedHash });
+      const isUnknownURI = none((r: Resolver) => r.canRead(file), this.options.resolve.resolvers);
+      const isURL = !isUnknownURI;
+      const isInternalReference = url.stripHash(this.reference.uri) === $refBaseURIStrippedHash;
+      const isExternalReference = !isInternalReference;
+
+      // internal Schema Object $refs resolve against the in-document $id graph;
+      // leaving them untouched keeps that resolution valid. A JSON Schema $ref is
+      // never normalized to a bare fragment.
+      if (isInternalReference) {
+        return;
+      }
+
+      // honor the resolve.external switch
+      if (!this.options.resolve.external && isExternalReference) {
+        return;
+      }
+
+      // detect maximum depth of bundling before fetching the external resource
+      if (this.reference.depth >= this.options.bundle.maxDepth) {
+        throw new MaximumBundleDepthError(
+          `Maximum bundle depth of "${this.options.bundle.maxDepth}" has been exceeded in file "${this.reference.uri}"`,
+          { maxDepth: this.options.bundle.maxDepth, uri: this.reference.uri },
+        );
+      }
+
+      // locate the external schema resource the $ref targets, reusing the
+      // dereference strategy's classification. First try to resolve the target
+      // as a canonical URI / URL against the current document's $id graph; if
+      // that fails, fall back to fetching the external document and resolving
+      // the fragment there as a $anchor or JSON Pointer.
+      let schemaReference = this.reference;
+      try {
+        const referenceAsSchema = maybeRefractToJSONSchemaElement(
+          (schemaReference.value as ParseResultElement).result as Element,
+        );
+        uriEvaluate($refBaseURI, referenceAsSchema);
+      } catch (error) {
+        if (isURL && error instanceof EvaluationJsonSchemaUriError) {
+          if (isAnchor(uriToAnchor($refBaseURI))) {
+            schemaReference = await this.toReference(url.unsanitize($refBaseURI));
+            const selector = uriToAnchor($refBaseURI);
+            const referenceAsSchema = maybeRefractToJSONSchemaElement(
+              (schemaReference.value as ParseResultElement).result as Element,
+            );
+            $anchorEvaluate(selector, referenceAsSchema);
+          } else {
+            schemaReference = await this.toReference(url.unsanitize($refBaseURI));
+            const selector = URIFragmentIdentifier.fromURIReference($refBaseURI);
+            const referenceAsSchema = maybeRefractToJSONSchemaElement(
+              (schemaReference.value as ParseResultElement).result as Element,
+            );
+            jsonPointerEvaluate(referenceAsSchema, selector);
+          }
+        } else {
+          throw error;
+        }
+      }
+
+      // a $ref that resolves (by $id/$anchor/pointer) within the current document
+      // is internal even when its URI form (e.g. a URN or absolute $id) is not a
+      // bare fragment. Leave it untouched — it resolves against the in-document
+      // $id graph, and embedding the current document into itself would be wrong.
+      if (url.stripHash(schemaReference.uri) === url.stripHash(this.reference.uri)) {
+        return;
+      }
+
+      // the resource to embed is the WHOLE external document (its root schema),
+      // identified by its $id. A $ref into a fragment of the document embeds the
+      // entire document resource once; the fragment keeps resolving against the
+      // embedded $id.
+      const resourceRoot = maybeRefractToJSONSchemaElement(
+        (schemaReference.value as ParseResultElement).result as Element,
+      ) as JSONSchemaElement;
+      const resourceBaseURI =
+        resolveSchema$idField(url.stripHash(schemaReference.uri), resourceRoot) ??
+        url.stripHash(schemaReference.uri);
+
+      const field = cf.inputs.name;
+      const canonicalKey = `${field}\t${resourceBaseURI}`;
+
+      // resource already embedded (or being embedded) — leave the referencing
+      // $ref untouched and stop. This also terminates circular external schema
+      // references, since the assignment is reserved BEFORE recursion.
+      if (this.assignments.has(canonicalKey)) {
+        path.skip();
+        return;
+      }
+
+      // own a copy of the resource and ensure it carries a $id so the unchanged
+      // $ref still resolves against it once embedded
+      const embeddedElement = cloneDeep(resourceRoot);
+      if (!isStringElement(embeddedElement.$id)) {
+        embeddedElement.set('$id', resourceBaseURI);
+      }
+
+      // the embedded thing is the WHOLE resource (keyed by its $id), so its name
+      // is derived from the resource URI
+      const preferredName = this.baseName(embeddedElement, resourceBaseURI);
+      const componentName = this.uniqueName(preferredName);
+
+      this.reportNameCollision(preferredName, componentName);
+
+      // reserve the assignment and component name before recursing so circular
+      // external schema references terminate
+      this.assignments.set(canonicalKey, `#/components/${field}/${escape(componentName)}`);
+      if (!this.reservedNames.has(field)) this.reservedNames.set(field, new Set<string>());
+      this.reservedNames.get(field)!.add(componentName);
+
+      // bundle external references contained within the embedded resource;
+      // nested external resources land flat in the same components.inputs
+      const visitor = new Arazzo1BundleVisitor({
+        reference: schemaReference,
+        options: this.options,
+        assignments: this.assignments,
+        reservedNames: this.reservedNames,
+      });
+      const bundledElement = (await traverseAsync(embeddedElement, visitor, {
+        mutable: true,
+      })) as JSONSchemaElement;
+
+      // annotate the embedded resource with info about its origin
+      if (isElement(bundledElement)) {
+        bundledElement.meta.set('ref-origin', schemaReference.uri);
+      }
+
+      // place the embedded resource into the entry document's components.inputs
+      this.ensureInputsField().set(componentName, bundledElement);
+
+      // the referencing $ref is left UNCHANGED — it resolves against the
+      // embedded resource's $id
+      path.skip();
+    } catch (error: unknown) {
+      this.handleError(
+        `Error while bundling JSON Schema Object. Cannot resolve $ref "${$ref}": ${(error as Error).message}`,
+        error as Error,
+        referencingElement,
+        '$ref',
+        $ref,
+        path,
+      );
+      path.skip();
+    }
+  }
+}
+
+export default Arazzo1BundleVisitor;

--- a/packages/apidom-reference/src/configuration/saturated.ts
+++ b/packages/apidom-reference/src/configuration/saturated.ts
@@ -33,6 +33,7 @@ import Overlay1DereferenceStrategy from '../dereference/strategies/overlay-1/ind
 import OpenAPI2BundleStrategy from '../bundle/strategies/openapi-2/index.ts';
 import OpenAPI3_0BundleStrategy from '../bundle/strategies/openapi-3-0/index.ts';
 import OpenAPI3_1BundleStrategy from '../bundle/strategies/openapi-3-1/index.ts';
+import Arazzo1BundleStrategy from '../bundle/strategies/arazzo-1/index.ts';
 import { options } from '../index.ts';
 
 options.parse.parsers = [
@@ -83,6 +84,7 @@ options.bundle.strategies = [
   new OpenAPI2BundleStrategy(),
   new OpenAPI3_0BundleStrategy(),
   new OpenAPI3_1BundleStrategy(),
+  new Arazzo1BundleStrategy(),
 ];
 
 export * from '../index.ts';

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/circular-external/person.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/circular-external/person.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "pet": {
+      "$ref": "./pet.json"
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/circular-external/pet.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/circular-external/pet.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "owner": {
+      "$ref": "./person.json"
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/circular-external/root.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/circular-external/root.json
@@ -1,0 +1,37 @@
+{
+  "arazzo": "1.0.1",
+  "info": {
+    "title": "circular external schema resources",
+    "version": "1.0.0"
+  },
+  "sourceDescriptions": [
+    {
+      "name": "petStore",
+      "url": "https://example.com/openapi.json",
+      "type": "openapi"
+    }
+  ],
+  "workflows": [
+    {
+      "workflowId": "testWorkflow",
+      "steps": [
+        {
+          "stepId": "step1",
+          "operationId": "petStore.getPet"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "inputs": {
+      "Person": {
+        "type": "object",
+        "properties": {
+          "person": {
+            "$ref": "./person.json"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/dynamic-ref/ex.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/dynamic-ref/ex.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://example.com/schemas/tree",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$dynamicAnchor": "node",
+  "type": "object",
+  "properties": {
+    "data": true,
+    "children": {
+      "type": "array",
+      "items": {
+        "$dynamicRef": "#node"
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/dynamic-ref/root.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/dynamic-ref/root.json
@@ -1,0 +1,32 @@
+{
+  "arazzo": "1.0.1",
+  "info": {
+    "title": "external schema using $dynamicRef and $dynamicAnchor",
+    "version": "1.0.0"
+  },
+  "sourceDescriptions": [
+    {
+      "name": "petStore",
+      "url": "https://example.com/openapi.json",
+      "type": "openapi"
+    }
+  ],
+  "workflows": [
+    {
+      "workflowId": "testWorkflow",
+      "steps": [
+        {
+          "stepId": "step1",
+          "operationId": "petStore.getPet"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "inputs": {
+      "Tree": {
+        "$ref": "./ex.json"
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/external-anchor/ex.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/external-anchor/ex.json
@@ -1,0 +1,17 @@
+{
+  "$id": "https://example.com/schemas/user",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "UserProfile": {
+      "$anchor": "user-profile",
+      "properties": {
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/external-anchor/root.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/external-anchor/root.json
@@ -1,0 +1,37 @@
+{
+  "arazzo": "1.0.1",
+  "info": {
+    "title": "external schema reference by $anchor",
+    "version": "1.0.0"
+  },
+  "sourceDescriptions": [
+    {
+      "name": "petStore",
+      "url": "https://example.com/openapi.json",
+      "type": "openapi"
+    }
+  ],
+  "workflows": [
+    {
+      "workflowId": "testWorkflow",
+      "steps": [
+        {
+          "stepId": "step1",
+          "operationId": "petStore.getPet"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "inputs": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "profile": {
+            "$ref": "./ex.json#user-profile"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/external-id-uri/ex.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/external-id-uri/ex.json
@@ -1,0 +1,10 @@
+{
+  "$id": "https://example.com/schemas/pet",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/external-id-uri/root.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/external-id-uri/root.json
@@ -1,0 +1,32 @@
+{
+  "arazzo": "1.0.1",
+  "info": {
+    "title": "external schema reference by absolute $id URI",
+    "version": "1.0.0"
+  },
+  "sourceDescriptions": [
+    {
+      "name": "petStore",
+      "url": "https://example.com/openapi.json",
+      "type": "openapi"
+    }
+  ],
+  "workflows": [
+    {
+      "workflowId": "testWorkflow",
+      "steps": [
+        {
+          "stepId": "step1",
+          "operationId": "petStore.getPet"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "inputs": {
+      "Pet": {
+        "$ref": "./ex.json"
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/external-pointer/ex.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/external-pointer/ex.json
@@ -1,0 +1,14 @@
+{
+  "$id": "https://example.com/schemas/pets",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "Pet": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/external-pointer/root.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/external-pointer/root.json
@@ -1,0 +1,37 @@
+{
+  "arazzo": "1.0.1",
+  "info": {
+    "title": "external schema reference by JSON Pointer",
+    "version": "1.0.0"
+  },
+  "sourceDescriptions": [
+    {
+      "name": "petStore",
+      "url": "https://example.com/openapi.json",
+      "type": "openapi"
+    }
+  ],
+  "workflows": [
+    {
+      "workflowId": "testWorkflow",
+      "steps": [
+        {
+          "stepId": "step1",
+          "operationId": "petStore.getPet"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "inputs": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "pet": {
+            "$ref": "./ex.json#/$defs/Pet"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/id-assignment/ex.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/id-assignment/ex.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/id-assignment/root.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/id-assignment/root.json
@@ -1,0 +1,32 @@
+{
+  "arazzo": "1.0.1",
+  "info": {
+    "title": "external schema resource without a $id",
+    "version": "1.0.0"
+  },
+  "sourceDescriptions": [
+    {
+      "name": "petStore",
+      "url": "https://example.com/openapi.json",
+      "type": "openapi"
+    }
+  ],
+  "workflows": [
+    {
+      "workflowId": "testWorkflow",
+      "steps": [
+        {
+          "stepId": "step1",
+          "operationId": "petStore.getPet"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "inputs": {
+      "Pet": {
+        "$ref": "./ex.json"
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/internal-by-id/root.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/internal-by-id/root.json
@@ -1,0 +1,46 @@
+{
+  "arazzo": "1.0.1",
+  "info": {
+    "title": "internal schema reference by $id",
+    "version": "1.0.0"
+  },
+  "sourceDescriptions": [
+    {
+      "name": "petStore",
+      "url": "https://example.com/openapi.json",
+      "type": "openapi"
+    }
+  ],
+  "workflows": [
+    {
+      "workflowId": "testWorkflow",
+      "steps": [
+        {
+          "stepId": "step1",
+          "operationId": "petStore.getPet"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "inputs": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "pet": {
+            "$ref": "urn:example:pet"
+          }
+        }
+      },
+      "Pet": {
+        "$id": "urn:example:pet",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/internal-only/root.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/internal-only/root.json
@@ -1,0 +1,45 @@
+{
+  "arazzo": "1.0.1",
+  "info": {
+    "title": "internal Schema Object references only",
+    "version": "1.0.0"
+  },
+  "sourceDescriptions": [
+    {
+      "name": "petStore",
+      "url": "https://example.com/openapi.json",
+      "type": "openapi"
+    }
+  ],
+  "workflows": [
+    {
+      "workflowId": "testWorkflow",
+      "steps": [
+        {
+          "stepId": "step1",
+          "operationId": "petStore.getPet"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "inputs": {
+      "Pet": {
+        "type": "object",
+        "properties": {
+          "owner": {
+            "$ref": "#/components/inputs/Person"
+          }
+        }
+      },
+      "Person": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/internal-ref-at-max-depth/ex.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/internal-ref-at-max-depth/ex.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "Node": {
+      "type": "object",
+      "properties": {
+        "self": {
+          "$ref": "#/$defs/Node"
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/internal-ref-at-max-depth/root.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/internal-ref-at-max-depth/root.json
@@ -1,0 +1,32 @@
+{
+  "arazzo": "1.0.1",
+  "info": {
+    "title": "internal schema ref inside external doc at max depth",
+    "version": "1.0.0"
+  },
+  "sourceDescriptions": [
+    {
+      "name": "petStore",
+      "url": "https://example.com/openapi.json",
+      "type": "openapi"
+    }
+  ],
+  "workflows": [
+    {
+      "workflowId": "testWorkflow",
+      "steps": [
+        {
+          "stepId": "step1",
+          "operationId": "petStore.getPet"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "inputs": {
+      "Node": {
+        "$ref": "./ex.json#/$defs/Node"
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/nested-external/item.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/nested-external/item.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "sku": {
+      "type": "string"
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/nested-external/order.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/nested-external/order.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "item": {
+      "$ref": "./item.json"
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/nested-external/root.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/nested-external/root.json
@@ -1,0 +1,37 @@
+{
+  "arazzo": "1.0.1",
+  "info": {
+    "title": "external schema that references another external schema",
+    "version": "1.0.0"
+  },
+  "sourceDescriptions": [
+    {
+      "name": "petStore",
+      "url": "https://example.com/openapi.json",
+      "type": "openapi"
+    }
+  ],
+  "workflows": [
+    {
+      "workflowId": "testWorkflow",
+      "steps": [
+        {
+          "stepId": "step1",
+          "operationId": "petStore.getPet"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "inputs": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "order": {
+            "$ref": "./order.json"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/shared-target/ex.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/shared-target/ex.json
@@ -1,0 +1,14 @@
+{
+  "$id": "https://example.com/schemas/pets",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "Pet": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/shared-target/root.json
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/fixtures/shared-target/root.json
@@ -1,0 +1,45 @@
+{
+  "arazzo": "1.0.1",
+  "info": {
+    "title": "two references to the same external schema resource",
+    "version": "1.0.0"
+  },
+  "sourceDescriptions": [
+    {
+      "name": "petStore",
+      "url": "https://example.com/openapi.json",
+      "type": "openapi"
+    }
+  ],
+  "workflows": [
+    {
+      "workflowId": "testWorkflow",
+      "steps": [
+        {
+          "stepId": "step1",
+          "operationId": "petStore.getPet"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "inputs": {
+      "Cat": {
+        "type": "object",
+        "properties": {
+          "friend": {
+            "$ref": "./ex.json#/$defs/Pet"
+          }
+        }
+      },
+      "Dog": {
+        "type": "object",
+        "properties": {
+          "rival": {
+            "$ref": "./ex.json#/$defs/Pet"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/index.ts
+++ b/packages/apidom-reference/test/bundle/strategies/arazzo-1/json-schema-object/index.ts
@@ -1,0 +1,379 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assert } from 'chai';
+import { toValue } from '@speclynx/apidom-core';
+import { Element, includesClasses, isParseResultElement } from '@speclynx/apidom-datamodel';
+import { mediaTypes } from '@speclynx/apidom-ns-arazzo-1';
+import { evaluate } from '@speclynx/apidom-json-pointer';
+
+import { bundle } from '../../../../../src/index.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootFixturePath = path.join(__dirname, 'fixtures');
+
+describe('bundle', function () {
+  context('strategies', function () {
+    context('arazzo-1', function () {
+      context('JSON Schema Object', function () {
+        context('given external Schema Object referenced by JSON Pointer', function () {
+          const fixturePath = path.join(rootFixturePath, 'external-pointer');
+          const rootFilePath = path.join(fixturePath, 'root.json');
+
+          specify('should produce a ParseResultElement', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+
+            assert.isTrue(isParseResultElement(bundled));
+          });
+
+          specify('should embed the whole external schema resource', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+            const inputs = toValue(
+              evaluate(bundled.result as Element, '/components/inputs'),
+            ) as Record<string, object>;
+
+            assert.containsAllKeys(inputs, ['pets']);
+            assert.deepEqual(inputs.pets, {
+              $id: 'https://example.com/schemas/pets',
+              $schema: 'https://json-schema.org/draft/2020-12/schema',
+              $defs: {
+                Pet: {
+                  type: 'object',
+                  properties: {
+                    name: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            });
+          });
+
+          specify('should produce a components-inputs named-content element', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+            const inputs = evaluate<Element>(bundled.result as Element, '/components/inputs');
+
+            assert.isTrue(includesClasses(inputs, ['components-inputs']));
+          });
+
+          specify('should leave the referencing $ref unchanged', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+
+            assert.strictEqual(
+              toValue(
+                evaluate(bundled.result as Element, '/components/inputs/User/properties/pet/$ref'),
+              ),
+              './ex.json#/$defs/Pet',
+            );
+          });
+
+          specify('should annotate the embedded resource with its origin', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+            const embedded = evaluate<Element>(
+              bundled.result as Element,
+              '/components/inputs/pets',
+            );
+
+            assert.match(toValue(embedded.meta.get('ref-origin')) as string, /ex\.json$/);
+          });
+        });
+
+        context('given external Schema Object referenced by absolute $id URI', function () {
+          const fixturePath = path.join(rootFixturePath, 'external-id-uri');
+          const rootFilePath = path.join(fixturePath, 'root.json');
+
+          specify('should embed the resource and leave the $ref unchanged', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+
+            assert.strictEqual(
+              toValue(evaluate(bundled.result as Element, '/components/inputs/pet/$id')),
+              'https://example.com/schemas/pet',
+            );
+            assert.strictEqual(
+              toValue(evaluate(bundled.result as Element, '/components/inputs/Pet/$ref')),
+              './ex.json',
+            );
+          });
+        });
+
+        context('given external Schema Object referenced by $anchor', function () {
+          const fixturePath = path.join(rootFixturePath, 'external-anchor');
+          const rootFilePath = path.join(fixturePath, 'root.json');
+
+          specify('should embed the resource carrying the anchor', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+
+            assert.strictEqual(
+              toValue(
+                evaluate(
+                  bundled.result as Element,
+                  '/components/inputs/user/$defs/UserProfile/$anchor',
+                ),
+              ),
+              'user-profile',
+            );
+          });
+
+          specify('should leave the $anchor reference unchanged', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+
+            assert.strictEqual(
+              toValue(
+                evaluate(
+                  bundled.result as Element,
+                  '/components/inputs/User/properties/profile/$ref',
+                ),
+              ),
+              './ex.json#user-profile',
+            );
+          });
+        });
+
+        context('given external Schema Object using $dynamicRef and $dynamicAnchor', function () {
+          const fixturePath = path.join(rootFixturePath, 'dynamic-ref');
+          const rootFilePath = path.join(fixturePath, 'root.json');
+
+          specify('should preserve $dynamicRef and $dynamicAnchor verbatim', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+
+            assert.strictEqual(
+              toValue(
+                evaluate(bundled.result as Element, '/components/inputs/tree/$dynamicAnchor'),
+              ),
+              'node',
+            );
+            assert.strictEqual(
+              toValue(
+                evaluate(
+                  bundled.result as Element,
+                  '/components/inputs/tree/properties/children/items/$dynamicRef',
+                ),
+              ),
+              '#node',
+            );
+          });
+        });
+
+        context('given two references to the same external schema resource', function () {
+          const fixturePath = path.join(rootFixturePath, 'shared-target');
+          const rootFilePath = path.join(fixturePath, 'root.json');
+
+          specify('should embed the resource only once', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+            const inputs = toValue(
+              evaluate(bundled.result as Element, '/components/inputs'),
+            ) as Record<string, object>;
+
+            assert.hasAllKeys(inputs, ['Cat', 'Dog', 'pets']);
+          });
+
+          specify('should leave both referencing $refs unchanged', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+
+            assert.strictEqual(
+              toValue(
+                evaluate(
+                  bundled.result as Element,
+                  '/components/inputs/Cat/properties/friend/$ref',
+                ),
+              ),
+              './ex.json#/$defs/Pet',
+            );
+            assert.strictEqual(
+              toValue(
+                evaluate(bundled.result as Element, '/components/inputs/Dog/properties/rival/$ref'),
+              ),
+              './ex.json#/$defs/Pet',
+            );
+          });
+        });
+
+        context('given an external schema that references another external schema', function () {
+          const fixturePath = path.join(rootFixturePath, 'nested-external');
+          const rootFilePath = path.join(fixturePath, 'root.json');
+
+          specify('should embed both resources flat into components.inputs', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+            const inputs = toValue(
+              evaluate(bundled.result as Element, '/components/inputs'),
+            ) as Record<string, object>;
+
+            assert.hasAllKeys(inputs, ['Order', 'order', 'item']);
+          });
+
+          specify('should leave the nested $ref unchanged', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+
+            assert.strictEqual(
+              toValue(
+                evaluate(
+                  bundled.result as Element,
+                  '/components/inputs/order/properties/item/$ref',
+                ),
+              ),
+              './item.json',
+            );
+          });
+        });
+
+        context('given circular external schema resources', function () {
+          const fixturePath = path.join(rootFixturePath, 'circular-external');
+          const rootFilePath = path.join(fixturePath, 'root.json');
+
+          specify('should terminate and embed each resource once', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+            const inputs = toValue(
+              evaluate(bundled.result as Element, '/components/inputs'),
+            ) as Record<string, object>;
+
+            assert.hasAllKeys(inputs, ['Person', 'person', 'pet']);
+          });
+
+          specify('should preserve the inner cross-resource $refs', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+
+            assert.strictEqual(
+              toValue(
+                evaluate(
+                  bundled.result as Element,
+                  '/components/inputs/person/properties/pet/$ref',
+                ),
+              ),
+              './pet.json',
+            );
+            assert.strictEqual(
+              toValue(
+                evaluate(bundled.result as Element, '/components/inputs/pet/properties/owner/$ref'),
+              ),
+              './person.json',
+            );
+          });
+        });
+
+        context('given an external Schema Object resource without a $id', function () {
+          const fixturePath = path.join(rootFixturePath, 'id-assignment');
+          const rootFilePath = path.join(fixturePath, 'root.json');
+
+          specify('should assign a $id derived from the retrieval URI', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+            const inputs = toValue(
+              evaluate(bundled.result as Element, '/components/inputs'),
+            ) as Record<string, { $id?: string }>;
+            const embedded = Object.values(inputs).find((schema) => typeof schema.$id === 'string');
+
+            assert.isDefined(embedded);
+            assert.match(embedded!.$id as string, /ex\.json$/);
+          });
+        });
+
+        context('given internal Schema Object references only', function () {
+          const fixturePath = path.join(rootFixturePath, 'internal-only');
+          const rootFilePath = path.join(fixturePath, 'root.json');
+
+          specify('should leave internal $refs untouched and embed nothing', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+            const inputs = toValue(
+              evaluate(bundled.result as Element, '/components/inputs'),
+            ) as Record<string, object>;
+
+            assert.hasAllKeys(inputs, ['Pet', 'Person']);
+            assert.strictEqual(
+              toValue(
+                evaluate(bundled.result as Element, '/components/inputs/Pet/properties/owner/$ref'),
+              ),
+              '#/components/inputs/Person',
+            );
+          });
+        });
+
+        context('given an internal Schema Object reference by $id', function () {
+          const fixturePath = path.join(rootFixturePath, 'internal-by-id');
+          const rootFilePath = path.join(fixturePath, 'root.json');
+
+          specify('should leave the $id reference untouched and embed nothing', async function () {
+            const bundled = await bundle(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+            const inputs = toValue(
+              evaluate(bundled.result as Element, '/components/inputs'),
+            ) as Record<string, object>;
+
+            // a $ref to a $id/URN defined within the entry document is internal
+            // even though its URI form is not a bare fragment — it must not embed
+            // the entry document into itself
+            assert.hasAllKeys(inputs, ['User', 'Pet']);
+            assert.strictEqual(
+              toValue(
+                evaluate(bundled.result as Element, '/components/inputs/User/properties/pet/$ref'),
+              ),
+              'urn:example:pet',
+            );
+          });
+        });
+
+        context(
+          'given an internal Schema Object reference inside a document at resolve.maxDepth',
+          function () {
+            const fixturePath = path.join(rootFixturePath, 'internal-ref-at-max-depth');
+            const rootFilePath = path.join(fixturePath, 'root.json');
+
+            specify(
+              'should leave the internal $ref untouched without resolving',
+              async function () {
+                // the embedded resource is reached at depth 1; an internal $ref
+                // within it needs no resolution and must not trip resolve.maxDepth
+                const bundled = await bundle(rootFilePath, {
+                  parse: { mediaType: mediaTypes.latest('json') },
+                  resolve: { maxDepth: 1 },
+                });
+
+                assert.strictEqual(
+                  toValue(
+                    evaluate(
+                      bundled.result as Element,
+                      '/components/inputs/ex/$defs/Node/properties/self/$ref',
+                    ),
+                  ),
+                  '#/$defs/Node',
+                );
+              },
+            );
+          },
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the **Arazzo 1.x bundle strategy**. Previously, bundling an Arazzo document threw `UnmatchedBundleStrategyError` because no strategy matched it.

The only external references Arazzo defines are **JSON Schema Objects** — a [JSON Schema 2020-12](https://json-schema.org/draft/2020-12) dialect used by Input Objects and inline schemas:

- **Reusable Objects** are internal-only runtime-expression references → nothing to bundle.
- **Source Descriptions** point at whole external documents that are intentionally kept external (like Overlay's `extends`) → not bundled.

So Schema Objects are bundled per the [JSON Schema Compound Document](https://json-schema.org/blog/posts/bundling-json-schema-compound-documents) rules, mirroring the `openapi-3-1` strategy's Schema Object handling:

- The whole external schema **resource** is embedded verbatim into `components.inputs`, carrying its `$id` (one is assigned from the retrieval URI when absent).
- The referencing `$ref` is left **unchanged** — it keeps resolving against the embedded resource's `$id`.
- References by JSON Pointer, `$id` URI, and `$anchor` are supported; `$dynamicRef`/`$dynamicAnchor` survive untouched.
- Nested external resources are embedded flat into `components.inputs`, deduplicated by resource URI.
- Internal references are preserved untouched.

Honors all bundle options (`componentNamesStrategy`, `onComponentNameCollision`, `continueOnError`, `maxDepth`, `immutable`, `refSet`) plus `strategyOpts['arazzo-1']`.

## Changes

- `src/bundle/strategies/arazzo-1/{index,visitor}.ts` — the strategy and its `JSONSchemaElement` bundling visitor
- `src/configuration/saturated.ts` — registers `Arazzo1BundleStrategy`
- `package.json` — adds the `./bundle/strategies/arazzo-1` subpath export
- `test/bundle/strategies/arazzo-1/json-schema-object/` — 19 specs across external pointer / `$anchor` / `$id` URI, `$dynamicRef`, shared target, nested external, circular external, `$id` assignment, internal-only, internal-by-id, and internal-ref-at-max-depth
- `README.md` — documents the strategy and adds it to the default execution-order list

## Testing

`npm test` in `apidom-reference`: **1447 passing**, 0 failing.