### PR TITLE
chore(deps): resolve Babel 8 peer dependency warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2100,19 +2100,32 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
-      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-8.0.1.tgz",
+      "integrity": "sha512-n0jtCOxEovhU7METqSQjcZO9pX53nu9uNIjMS+hEt+Nt9jA7oOZoBIgbCxhhASmF6T6rPDGge5UAvh6Z4eFz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx/node_modules/@babel/helper-plugin-utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+      "integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
@@ -2226,19 +2239,32 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
-      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-8.0.3.tgz",
+      "integrity": "sha512-jmTPwps7oSQSZaV1SxkQ3C12UWyufGysGc5OzDpZzvPAIX4mO7dJT3hoqkWVrSImvkcMiknir1iLN1SNV/CZzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
+        "@babel/helper-plugin-utils": "^8.0.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript/node_modules/@babel/helper-plugin-utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+      "integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
@@ -4269,22 +4295,6 @@
         "@babel/core": "^8.0.0"
       }
     },
-    "node_modules/@babel/plugin-transform-typescript/node_modules/@babel/plugin-syntax-typescript": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-8.0.1.tgz",
-      "integrity": "sha512-YBpIeuOZSUZx7RGH/U+dIAsHDHyojBVDRHNBUgOiUDS5IIcgBm1uyu9xs/2kM27B/bmDfOxzJ9k8cU2QuOwGIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^8.0.1"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^8.0.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-8.0.1.tgz",
@@ -6255,9 +6265,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6311,9 +6321,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6349,9 +6359,9 @@
       }
     },
     "node_modules/@jest/diff-sequences": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
-      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6359,16 +6369,16 @@
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jest-get-type": "^29.6.3"
+        "@jest/get-type": "30.1.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/get-type": {
@@ -6408,6 +6418,78 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils/node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils/node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils/node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/test-result": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
@@ -6425,264 +6507,116 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/types": "^29.6.3",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "babel-plugin-istanbul": "^6.1.1",
-        "chalk": "^4.0.0",
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "pirates": "^4.0.4",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "pirates": "^4.0.7",
         "slash": "^3.0.0",
-        "write-file-atomic": "^4.0.2"
+        "write-file-atomic": "^5.0.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/transform/node_modules/@babel/compat-data": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/@babel/core": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+    "node_modules/@jest/transform/node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helpers": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
       },
       "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/@babel/helper-compilation-targets": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/@babel/helper-module-transforms": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/@babel/helper-validator-option": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/@babel/helpers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/transform/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
+        "@sinclair/typebox": "^0.34.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/transform/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
         "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@jest/transform/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/jest-haste-map": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/transform/node_modules/jest-regex-util": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/transform/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.3",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/transform/node_modules/jest-worker": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+    "node_modules/@jest/transform/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@jest/transform/node_modules/slash": {
@@ -6693,20 +6627,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/write-file-atomic": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/@jest/types": {
@@ -6735,17 +6655,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -7739,9 +7648,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.5.tgz",
-      "integrity": "sha512-eoPtwx0qZqvRUD+VVOHm150AlSYwYoPxkDHBBGqKCn5nzPspb0lLWw8q83crM/L1M928YgK0WmGf3C++7eqsTA==",
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.6.tgz",
+      "integrity": "sha512-FBKG9Tqrl8H0A4oIekVTJNNq+tRMrkyF0fLBV4Cpi9Hm1ejA8dl5gpEG/o5V7MwiClVddDwtXp1ymdCa2qSoyg==",
       "cpu": [
         "arm64"
       ],
@@ -7753,9 +7662,9 @@
       ]
     },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.5.tgz",
-      "integrity": "sha512-VLOn/ZoEn3HfjSj+yIHLCM56/el79r+9I28CkZNHaSXJQWZ3edSkcgcfYjVxCurpN2VEwDQHLBeFCH8M+lQ7wQ==",
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.6.tgz",
+      "integrity": "sha512-IpXL2NYYBDj9k+7u6jEdKpWOqPGZNBpGcW+LyY3l5qoyaa0lq3gzZrDNae9XP2dmGwnUn1kD9OTgq9kmkcK3Bg==",
       "cpu": [
         "x64"
       ],
@@ -7767,9 +7676,9 @@
       ]
     },
     "node_modules/@nx/nx-freebsd-x64": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.5.tgz",
-      "integrity": "sha512-LEVer/E2xfGvK9Go+imMQoEninOoq/38Z2bhV1SD3AThXrp1xaLFVkW5jQ6juebeVkAeztEoMLFlr576egS0vw==",
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.6.tgz",
+      "integrity": "sha512-1QVXcfu0FiVyfd6GLBKIWNuGtPh/Pbjhwyhucc/kI2EgV1f+Sl6kePDp2pI8PQ00HKVLy/NqAwgcx05YyGtYYg==",
       "cpu": [
         "x64"
       ],
@@ -7781,9 +7690,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.5.tgz",
-      "integrity": "sha512-NP27EFGpmFJM6RL1Ey/AFJ7gA2xuqtIHaw6jjSNGvfrnZRUNaway30GrVaGGeODf0DsvAty/unqoBMPy6kDHbw==",
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.6.tgz",
+      "integrity": "sha512-YD6vjl39oxtR8kxxq9Ow/bFahb61M1soVMPz7dEhV3weM3/h3yRLdcscibvayIJ5nBFLxlYpXHG/n9qWxon8tw==",
       "cpu": [
         "arm"
       ],
@@ -7795,16 +7704,13 @@
       ]
     },
     "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.5.tgz",
-      "integrity": "sha512-QLnkJl3HkHsPfpLiNiAiMfpfAeFpic0U1diAxF8RqChOkCpQ7ulvyBVgE1UrQxvhd+gFQ3ed5RNDxtCRw8nTiw==",
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.6.tgz",
+      "integrity": "sha512-kMIpH8KvNUsbekkbcWGI+h3FnVOr+jL6cHv7r8Mvh1SusQzgxYcxE8iy0mPXcdbkfF5eaU9RcLB+uIKTyt8OmQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7812,16 +7718,13 @@
       ]
     },
     "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.5.tgz",
-      "integrity": "sha512-cEP6KmwBgnb38+jTTaibWCjwXcHmigqhTfy0tN1be7WZr6bHxbqNLsXqKRN70PSNA3HouZcxw1cdRL8tqbPBBA==",
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.6.tgz",
+      "integrity": "sha512-FsRoirT/wx7vdGl7fvkssyBvzu/JoZYYosBPDycaPg5LxSb2lPrvzcCcqG3c++jtSOn/IbbjGBA1bi8ApQ/Ulw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7829,16 +7732,13 @@
       ]
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.5.tgz",
-      "integrity": "sha512-tbaX1tZCSpGifDNBfDdEZAMxVF3Yg4bhFP/bm1needc0diqb+Zflc0u5tM5/6BWDMITQDwenJVsNiQ8ZdtJURA==",
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.6.tgz",
+      "integrity": "sha512-SA1nPymYHgi2NP2ra9r1hrSc+6jTR5xPTzjUhzNFXAColvgUO/aP0Gn+dXhwOtzzau8fKVc3K1qaHi+kIHT54g==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7846,16 +7746,13 @@
       ]
     },
     "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.5.tgz",
-      "integrity": "sha512-H0M7csOZIgPT822LqjxSXzf4MXRND15vIkAQe3F3Jlr3Si8LC3tzbL52aVcRfgb8MF/xOB5U47mSwxWt1M2bPQ==",
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.6.tgz",
+      "integrity": "sha512-Aeol4pSRuMuAEC16Se+WS+Xar8W6pymCDmRaIWNLhbDG/+JQqvvuW1izrMLD9DY1Vpn+acN3bHLvdHhTux/DZw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7863,9 +7760,9 @@
       ]
     },
     "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.5.tgz",
-      "integrity": "sha512-JTcZch9YAnDL1gbhqePz3DZ4x7iYemLn1yJzrjbbXAmXju2eiiJiZvJJHbV06+SP9HKXDT8RjTKuAWTdVxnHug==",
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.6.tgz",
+      "integrity": "sha512-iNdxFfvkePnAYRhKyEEVfskiiL2QdiALeeZG+STh+rfD15cUO2YiQU+iQzgpzqmi9J2QjhGykIdFA6E/8v09lg==",
       "cpu": [
         "arm64"
       ],
@@ -7877,9 +7774,9 @@
       ]
     },
     "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.5.tgz",
-      "integrity": "sha512-ngcMyHdBJ9FSz2nHdbZ7gtJlFq0O2b05sPAsVMkZ18CKzdaA1qrBDJfsMO49hPCny505eiT766+CkKdaCDl5kA==",
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.6.tgz",
+      "integrity": "sha512-thikDrOhCbUdzx5fQcpM34qZ7LV5RiszoNVG4m4TS3wAvx2bl+/qnVL6F6PwMlS6B/RVv6TqPhTuGHT7sjEGTA==",
       "cpu": [
         "x64"
       ],
@@ -8559,9 +8456,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8579,9 +8473,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8599,9 +8490,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8619,9 +8507,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8639,9 +8524,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8659,9 +8541,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8705,40 +8584,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
@@ -8923,9 +8768,9 @@
       }
     },
     "node_modules/@sigstore/core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.1.0.tgz",
-      "integrity": "sha512-o5cw1QYhNQ9IroioJxpzexmPjfCe7gzafd2RY3qnMpxr4ZEja+Jad/U8sgFpaue6bOaF+z7RVkyKVV44FN+N8A==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.2.1.tgz",
+      "integrity": "sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -8933,9 +8778,9 @@
       }
     },
     "node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.0.tgz",
-      "integrity": "sha512-MM8XIwUjN2bwvCg1QvrMtbBmpcSHrkhFSCu1D11NyPvDQ25HEc4oG5/OcQfd/Tlf/OxmKWERDj0zGE23jQaMwA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.1.tgz",
+      "integrity": "sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -8943,32 +8788,43 @@
       }
     },
     "node_modules/@sigstore/sign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.0.tgz",
-      "integrity": "sha512-Vx1RmLxLGnSUqx/o5/VsCjkuN5L7y+vxEEwawvc7u+6WtX2W4GNa7b9HEjmcRWohw/d6BpATXmvOwc78m+Swdg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.1.tgz",
+      "integrity": "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.3",
-        "proc-log": "^6.1.0",
-        "promise-retry": "^2.0.1"
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/@sigstore/sign/node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@sigstore/sign/node_modules/make-fetch-happen": {
-      "version": "15.0.4",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.4.tgz",
-      "integrity": "sha512-vM2sG+wbVeVGYcCm16mM3d5fuem9oC28n436HjsGO3LcxoTI8LNVa4rwZDn3f76+cWyT4GGJDxjTYU1I2nr6zw==",
+      "version": "15.0.6",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
+      "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
         "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
         "cacache": "^20.0.1",
         "http-cache-semantics": "^4.1.1",
         "minipass": "^7.0.2",
@@ -9038,9 +8894,9 @@
       }
     },
     "node_modules/@sigstore/tuf": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.1.tgz",
-      "integrity": "sha512-OPZBg8y5Vc9yZjmWCHrlWPMBqW5yd8+wFNl+thMdtcWz3vjVSoJQutF8YkrzI0SLGnkuFof4HSsWUhXrf219Lw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
+      "integrity": "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9052,14 +8908,14 @@
       }
     },
     "node_modules/@sigstore/verify": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.0.tgz",
-      "integrity": "sha512-mNe0Iigql08YupSOGv197YdHpPPr+EzDZmfCgMc7RPNaZTw5aLN01nBl6CHJOh3BGtnMIj83EeN4butBchc8Ag==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.1.tgz",
+      "integrity": "sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
@@ -9324,18 +9180,6 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
-    "node_modules/@swaggerexpert/arazzo-runtime-expression": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@swaggerexpert/arazzo-runtime-expression/-/arazzo-runtime-expression-2.0.3.tgz",
-      "integrity": "sha512-iGzCT3a6edX/LyQFhaR5l1JEyGtCQArGVjKDk8T7biaz24TE3CgDUMyeWzhGq9x7GBDj6KsxkI1WKEdERiDT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "apg-lite": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=16.14.0"
-      }
-    },
     "node_modules/@swaggerexpert/json-pointer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@swaggerexpert/json-pointer/-/json-pointer-3.0.1.tgz",
@@ -9481,16 +9325,6 @@
       "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/graceful-fs": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
-      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -11061,20 +10895,23 @@
       }
     },
     "node_modules/babel-plugin-istanbul": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "workspaces": [
+        "test/babel-8"
+      ],
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-instrument": "^5.0.4",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
         "test-exclude": "^6.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -13503,16 +13340,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/diff-sequences": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -14566,59 +14393,68 @@
       }
     },
     "node_modules/expect": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0"
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/expect/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
+        "@sinclair/typebox": "^0.34.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/expect/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
         "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
-    },
-    "node_modules/expect/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/expect/node_modules/ansi-styles": {
       "version": "5.2.0",
@@ -14633,74 +14469,83 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/expect/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/expect/node_modules/jest-message-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
+        "stack-utils": "^2.0.6"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/expect/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.3",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/expect/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/expect/node_modules/slash": {
@@ -17079,130 +16924,33 @@
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
         "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/@babel/compat-data": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/@babel/core": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helpers": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/@babel/helper-compilation-targets": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/@babel/helper-module-transforms": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/@babel/helper-validator-option": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/@babel/helpers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/iterator.prototype": {
@@ -17258,29 +17006,61 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
-      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/diff-sequences": "30.3.0",
+        "@jest/diff-sequences": "30.4.0",
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "pretty-format": "30.3.0"
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-get-type": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+    "node_modules/jest-diff/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-haste-map": {
@@ -17396,40 +17176,33 @@
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-matcher-utils/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
+        "@sinclair/typebox": "^0.34.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
-    },
-    "node_modules/jest-matcher-utils/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
       "version": "5.2.0",
@@ -17444,35 +17217,20 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-matcher-utils/node_modules/jest-diff": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^29.6.3",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-message-util": {
@@ -17517,6 +17275,108 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock/node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock/node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock/node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock/node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/jest-pnp-resolver": {
@@ -17665,194 +17525,83 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
-      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@babel/generator": "^7.7.2",
-        "@babel/plugin-syntax-jsx": "^7.7.2",
-        "@babel/plugin-syntax-typescript": "^7.7.2",
-        "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "babel-preset-current-node-syntax": "^1.0.0",
-        "chalk": "^4.0.0",
-        "expect": "^29.7.0",
-        "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^29.7.0",
-        "semver": "^7.5.3"
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/@babel/compat-data": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/@babel/core": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+    "node_modules/jest-snapshot/node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helpers": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
       },
       "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/@babel/helper-compilation-targets": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/@babel/helper-module-transforms": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/@babel/helper-validator-option": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/@babel/helpers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-snapshot/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
+        "@sinclair/typebox": "^0.34.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-snapshot/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
         "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
-    },
-    "node_modules/jest-snapshot/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/jest-snapshot/node_modules/ansi-styles": {
       "version": "5.2.0",
@@ -17867,100 +17616,83 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-snapshot/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/jest-diff": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^29.6.3",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-snapshot/node_modules/jest-message-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
+        "stack-utils": "^2.0.6"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-snapshot/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.3",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+    "node_modules/jest-snapshot/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/jest-snapshot/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
@@ -21166,9 +20898,9 @@
       }
     },
     "node_modules/nx": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-22.7.5.tgz",
-      "integrity": "sha512-zoxsJabb33jl1QYnalDn0bicryrEBgSzdKp90d7VGGv/jDgzKrcLg/hw2ZxeYiOjWPIT/o8QNT9G9vTs4dv3AQ==",
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-22.7.6.tgz",
+      "integrity": "sha512-cT2iX6NAtuNT/yaMTtwpIuNQBrW2Zhg4X8zdTEo/h27bz/JYnFm7B9MAKbAXNWK6k0Yxz+jv7zJoMBHutd1Dww==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -21220,7 +20952,7 @@
         "figures": "3.2.0",
         "flat": "5.0.2",
         "follow-redirects": "1.16.0",
-        "form-data": "4.0.5",
+        "form-data": "4.0.6",
         "fs-constants": "1.0.0",
         "function-bind": "1.1.2",
         "get-caller-file": "2.0.5",
@@ -21230,7 +20962,7 @@
         "has-flag": "4.0.0",
         "has-symbols": "1.1.0",
         "has-tostringtag": "1.0.2",
-        "hasown": "2.0.2",
+        "hasown": "2.0.4",
         "ieee754": "1.2.1",
         "ignore": "7.0.5",
         "inherits": "2.0.4",
@@ -21271,7 +21003,7 @@
         "strip-bom": "3.0.0",
         "supports-color": "7.2.0",
         "tar-stream": "2.2.0",
-        "tmp": "0.2.6",
+        "tmp": "0.2.7",
         "tree-kill": "1.2.2",
         "tsconfig-paths": "4.2.0",
         "tslib": "2.8.1",
@@ -21289,16 +21021,16 @@
         "nx-cloud": "dist/bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "22.7.5",
-        "@nx/nx-darwin-x64": "22.7.5",
-        "@nx/nx-freebsd-x64": "22.7.5",
-        "@nx/nx-linux-arm-gnueabihf": "22.7.5",
-        "@nx/nx-linux-arm64-gnu": "22.7.5",
-        "@nx/nx-linux-arm64-musl": "22.7.5",
-        "@nx/nx-linux-x64-gnu": "22.7.5",
-        "@nx/nx-linux-x64-musl": "22.7.5",
-        "@nx/nx-win32-arm64-msvc": "22.7.5",
-        "@nx/nx-win32-x64-msvc": "22.7.5"
+        "@nx/nx-darwin-arm64": "22.7.6",
+        "@nx/nx-darwin-x64": "22.7.6",
+        "@nx/nx-freebsd-x64": "22.7.6",
+        "@nx/nx-linux-arm-gnueabihf": "22.7.6",
+        "@nx/nx-linux-arm64-gnu": "22.7.6",
+        "@nx/nx-linux-arm64-musl": "22.7.6",
+        "@nx/nx-linux-x64-gnu": "22.7.6",
+        "@nx/nx-linux-x64-musl": "22.7.6",
+        "@nx/nx-win32-arm64-msvc": "22.7.6",
+        "@nx/nx-win32-x64-msvc": "22.7.6"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.11.1",
@@ -21412,36 +21144,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/nx/node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/nx/node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/nx/node_modules/ignore": {
@@ -24109,18 +23811,18 @@
       "license": "ISC"
     },
     "node_modules/sigstore": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.0.tgz",
-      "integrity": "sha512-/fUgUhYghuLzVT/gaJoeVehLCgZiUxPCPMcyVNY0lIf/cTCz58K/WTI7PefDarXxp9nUKpEwg1yyz3eSBMTtgA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.1.tgz",
+      "integrity": "sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "@sigstore/sign": "^4.1.0",
-        "@sigstore/tuf": "^4.0.1",
-        "@sigstore/verify": "^3.1.0"
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -25051,9 +24753,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25221,9 +24923,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -26612,13 +26314,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -27387,6 +27082,18 @@
       "devDependencies": {
         "@types/picomatch": "^4.0.3",
         "axios-mock-adapter": "^2.0.0"
+      }
+    },
+    "packages/apidom-reference/node_modules/@swaggerexpert/arazzo-runtime-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@swaggerexpert/arazzo-runtime-expression/-/arazzo-runtime-expression-2.0.3.tgz",
+      "integrity": "sha512-iGzCT3a6edX/LyQFhaR5l1JEyGtCQArGVjKDk8T7biaz24TE3CgDUMyeWzhGq9x7GBDj6KsxkI1WKEdERiDT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "apg-lite": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=16.14.0"
       }
     },
     "packages/apidom-reference/node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,10 @@
     "yaml-js": "^0.3.1"
   },
   "overrides": {
-    "minimatch@10.2.3": "10.2.4"
+    "minimatch@10.2.3": "10.2.4",
+    "jest-snapshot": "^30.4.1",
+    "@babel/core": "$@babel/core",
+    "@babel/plugin-syntax-jsx": "^8.0.0",
+    "@babel/plugin-syntax-typescript": "^8.0.0"
   }
 }

--- a/packages/apidom-converter/test/__snapshots__/index.mjs.snap
+++ b/packages/apidom-converter/test/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`apidom-converter convert given URI should convert 1`] = `
 {

--- a/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/info-summary/__snapshots__/index.mjs.snap
+++ b/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/info-summary/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`converter strategies openapi-3-1-to-openapi-3-0-3 info-summary should remove Info.summary field 1`] = `
 {

--- a/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/license-identifier/__snapshots__/index.mjs.snap
+++ b/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/license-identifier/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`converter strategies openapi-3-1-to-openapi-3-0-3 license-identifier should remove License.identifier field 1`] = `
 {

--- a/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/openapi-version/__snapshots__/index.mjs.snap
+++ b/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/openapi-version/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`converter strategies openapi-3-1-to-openapi-3-0-3 openapi-version should convert OpenAPI version 1`] = `
 {

--- a/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/reference-description/__snapshots__/index.mjs.snap
+++ b/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/reference-description/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`converter strategies openapi-3-1-to-openapi-3-0-3 reference-description should remove Reference.description field 1`] = `
 {

--- a/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/reference-summary/__snapshots__/index.mjs.snap
+++ b/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/reference-summary/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`converter strategies openapi-3-1-to-openapi-3-0-3 reference-summary should remove Reference.summary field 1`] = `
 {

--- a/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/security-requirements-empty-roles/__snapshots__/index.mjs.snap
+++ b/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/security-requirements-empty-roles/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`converter strategies openapi-3-1-to-openapi-3-0-3 security-requirements-empty-roles should set SecurityRequirement object to an empty array if it has SecurityScheme object type other than "oauth2" and "openIdConnect" 1`] = `
 {

--- a/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/security-scheme-type/__snapshots__/index.mjs.snap
+++ b/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/security-scheme-type/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`converter strategies openapi-3-1-to-openapi-3-0-3 security-scheme-type should remove Reference Objects pointing to removable Security Scheme Objects 1`] = `
 {

--- a/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/webhooks/__snapshots__/index.mjs.snap
+++ b/packages/apidom-converter/test/strategies/openapi-3-1-to-openapi-3-0-3/refractor-plugins/webhooks/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`converter strategies openapi-3-1-to-openapi-3-0-3 webhooks should remove OpenAPI.webhooks field 1`] = `
 {

--- a/packages/apidom-core/test/refractor/__snapshots__/index.mjs.snap
+++ b/packages/apidom-core/test/refractor/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor given POJO in object literal shape should refract to Object Element 1`] = `
 {

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/Arazzo/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/Arazzo/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ArazzoElement should refract to semantic ApiDOM tree 1`] = `(ArazzoElement)`;

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/ArazzoSpecification1/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/ArazzoSpecification1/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ArazzoSpecification1Element should refract to semantic ApiDOM tree 1`] = `
 (ArazzoSpecification1Element

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/Components/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/Components/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ComponentsElement should refract to semantic ApiDOM tree 1`] = `
 (ComponentsElement

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/Criterion/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/Criterion/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements CriterionElement should refract to semantic ApiDOM tree 1`] = `
 (CriterionElement

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/CriterionExpressionType/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/CriterionExpressionType/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements CriterionExpressionTypeElement should refract to semantic ApiDOM tree 1`] = `
 (CriterionExpressionTypeElement

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/FailureAction/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/FailureAction/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements FailureActionElement should refract to semantic ApiDOM tree 1`] = `
 (FailureActionElement

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/Info/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/Info/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements InfoElement given generic ApiDOM element should refract to semantic ApiDOM tree 1`] = `(InfoElement)`;
 

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/JSONSchema/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/JSONSchema/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements JSONSchemaElement given Boolean JSON Schemas should refract to semantic ApiDOM tree 1`] = `
 (JSONSchemaElement

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/Parameter/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/Parameter/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ParameterElement should refract to semantic ApiDOM tree 1`] = `
 (ParameterElement

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/PayloadReplacement/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/PayloadReplacement/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements PayloadReplacementElement should refract to semantic ApiDOM tree 1`] = `
 (PayloadReplacementElement

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/RequestBody/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/RequestBody/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements RequestBodyElement should refract to semantic ApiDOM tree 1`] = `
 (RequestBodyElement

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/Reusable/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/Reusable/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ReusableElement should refract to semantic ApiDOM tree 1`] = `
 (ReusableElement

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/SourceDescription/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/SourceDescription/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SourceDescriptionElement should refract to semantic ApiDOM tree 1`] = `
 (SourceDescriptionElement

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/Step/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/Step/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements StepElement should refract to semantic ApiDOM tree 1`] = `
 (StepElement

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/SuccessAction/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/SuccessAction/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SuccessActionElement should refract to semantic ApiDOM tree 1`] = `
 (SuccessActionElement

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/Workflow/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/Workflow/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements WorkflowElement should refract to semantic ApiDOM tree 1`] = `
 (WorkflowElement

--- a/packages/apidom-ns-arazzo-1/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
+++ b/packages/apidom-ns-arazzo-1/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given empty value instead of InfoElement should replace empty value with semantic element 1`] = `
 (ArazzoSpecification1Element

--- a/packages/apidom-ns-asyncapi-2/test/refractor/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor given generic ApiDOM object in AsyncApi 2.0.0 shape should refract to AsyncApi2Element 1`] = `
 {

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/AsyncApi2-0/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/AsyncApi2-0/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements AsyncApi2Element should refract to semantic ApiDOM tree 1`] = `
 (AsyncApi2Element

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/AsyncApiVersion/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/AsyncApiVersion/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements AsyncApiVersionElement should refract to semantic ApiDOM tree 1`] = `(AsyncApiVersionElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/ChannelBindings/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/ChannelBindings/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ChannelBindingsElement should refract to semantic ApiDOM tree 1`] = `
 (ChannelBindingsElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/ChannelItem/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/ChannelItem/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ChannelItemElement given bindings field of type ChannelBindingsElement should refract to semantic ApiDOM tree 1`] = `
 (ChannelItemElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/Channels/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/Channels/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ChannelsElement should refract to semantic ApiDOM tree 1`] = `
 (ChannelsElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/Components/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/Components/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ComponentsElement should refract to semantic ApiDOM tree 1`] = `
 (ComponentsElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/Contact/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/Contact/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ContactElement should refract to semantic ApiDOM tree 1`] = `
 (ContactElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/CorrelationID/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/CorrelationID/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements CorrelationIDElement should refract to semantic ApiDOM tree 1`] = `
 (CorrelationIDElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/DefaultContentType/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/DefaultContentType/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements DefaultContentTypeElement should refract to semantic ApiDOM tree 1`] = `(DefaultContentTypeElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/ExternalDocumentation/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/ExternalDocumentation/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ExternalDocumentationElement should refract to semantic ApiDOM tree 1`] = `
 (ExternalDocumentationElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/Identifier/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/Identifier/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements IdentifierElement should refract to semantic ApiDOM tree 1`] = `(IdentifierElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/Info/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/Info/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements InfoElement should refract to semantic ApiDOM tree 1`] = `
 (InfoElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/License/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/License/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements LicenseElement should refract to semantic ApiDOM tree 1`] = `
 (LicenseElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/Message/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/Message/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements MessageElement should refract to semantic ApiDOM tree 1`] = `
 (MessageElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/MessageBindings/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/MessageBindings/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements MessageBindingsElement should refract to semantic ApiDOM tree 1`] = `
 (MessageBindingsElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/MessageExample/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/MessageExample/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements MessageExampleElement should refract to semantic ApiDOM tree 1`] = `
 (MessageExampleElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/MessageTrait/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/MessageTrait/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements MessageTraitElement should refract to semantic ApiDOM tree 1`] = `
 (MessageTraitElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/OAuthFlow/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/OAuthFlow/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OAuthFlowElement should refract to semantic ApiDOM tree 1`] = `
 (OAuthFlowElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/OAuthFlows/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/OAuthFlows/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OAuthFlowsElement should refract to semantic ApiDOM tree 1`] = `
 (OAuthFlowsElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/Operation/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/Operation/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OperationElement given bindings field of type OperationBindingsElement should refract to semantic ApiDOM tree 1`] = `
 (OperationElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/OperationBindings/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/OperationBindings/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OperationBindingsElement should refract to semantic ApiDOM tree 1`] = `
 (OperationBindingsElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/OperationTrait/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/OperationTrait/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OperationTraitElement given bindings field of type OperationBindingsElement should refract to semantic ApiDOM tree 1`] = `
 (OperationTraitElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/Parameter/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/Parameter/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ParameterElement given schema field of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (ParameterElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/Parameters/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/Parameters/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ParametersElement should refract to semantic ApiDOM tree 1`] = `
 (ParametersElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/Reference/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/Reference/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ReferenceElement given generic ApiDOM element should refract to semantic ApiDOM tree 1`] = `
 (ReferenceElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/Schema/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/Schema/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SchemaElement given embedded SchemaElements should refract to semantic ApiDOM tree 1`] = `
 (SchemaElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/SecurityRequirement/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/SecurityRequirement/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SecurityRequirementElement should refract to semantic ApiDOM tree 1`] = `
 (SecurityRequirementElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/SecurityScheme/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/SecurityScheme/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SecurityScheme should refract to semantic ApiDOM tree 1`] = `
 (SecuritySchemeElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/Server/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/Server/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ServerElement given bindings field of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (ServerElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/ServerBindings/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/ServerBindings/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ServerBindingsElement should refract to semantic ApiDOM tree 1`] = `
 (ServerBindingsElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/ServerVariable/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/ServerVariable/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ServerVariableElement should refract to semantic ApiDOM tree 1`] = `
 (ServerVariableElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/Servers/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/Servers/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ServersElement should refract to semantic ApiDOM tree 1`] = `
 (ServersElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/Tag/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/Tag/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements TagElement should refract to semantic ApiDOM tree 1`] = `
 (TagElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/Tags/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/Tags/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements TagsElement should refract to semantic ApiDOM tree 1`] = `
 (TagsElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp/AmqpChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp/AmqpChannelBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements AmqpChannelBindingElement should refract to semantic ApiDOM tree 1`] = `
 (AmqpChannelBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp/AmqpMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp/AmqpMessageBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements AmqpMessageBindingElement should refract to semantic ApiDOM tree 1`] = `
 (AmqpMessageBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp/AmqpOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp/AmqpOperationBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements AmqpOperationBindingElement should refract to semantic ApiDOM tree 1`] = `
 (AmqpOperationBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp/AmqpServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp/AmqpServerBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements AmqpServerBindingElement should refract to semantic ApiDOM tree 1`] = `(AmqpServerBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp1/Amqp1ChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp1/Amqp1ChannelBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements Amqp1ChannelBindingElement should refract to semantic ApiDOM tree 1`] = `(Amqp1ChannelBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp1/Amqp1MessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp1/Amqp1MessageBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements Amqp1MessageBindingElement should refract to semantic ApiDOM tree 1`] = `(Amqp1MessageBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp1/Amqp1OperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp1/Amqp1OperationBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements Amqp1OperationBindingElement should refract to semantic ApiDOM tree 1`] = `(Amqp1OperationBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp1/Amqp1ServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/amqp1/Amqp1ServerBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements Amqp1ServerBindingElement should refract to semantic ApiDOM tree 1`] = `(Amqp1ServerBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/anypointmq/AnypointmqChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/anypointmq/AnypointmqChannelBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements AnypointmqChannelBindingElement should refract to semantic ApiDOM tree 1`] = `
 (AnypointmqChannelBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/anypointmq/AnypointmqMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/anypointmq/AnypointmqMessageBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements AnypointmqMessageBindingElement given headers field of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (AnypointmqMessageBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/anypointmq/AnypointmqOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/anypointmq/AnypointmqOperationBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements AnypointmqOperationBindingElement should refract to semantic ApiDOM tree 1`] = `(AnypointmqOperationBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/anypointmq/AnypointmqServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/anypointmq/AnypointmqServerBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements AnypointmqServerBindingElement should refract to semantic ApiDOM tree 1`] = `(AnypointmqServerBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/googlepubsub/googlepubsubChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/googlepubsub/googlepubsubChannelBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements GooglepubsubChannelBindingElement should refract to semantic ApiDOM tree 1`] = `
 (GooglepubsubChannelBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/googlepubsub/googlepubsubMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/googlepubsub/googlepubsubMessageBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements GooglepubsubChannelBindingElement should refract to semantic ApiDOM tree 1`] = `
 (GooglepubsubMessageBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/googlepubsub/googlepubsubOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/googlepubsub/googlepubsubOperationBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements GooglepubsubOperationBindingElement should refract to semantic ApiDOM tree 1`] = `(GooglepubsubOperationBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/googlepubsub/googlepubsubServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/googlepubsub/googlepubsubServerBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements GooglepubsubServerBindingElement should refract to semantic ApiDOM tree 1`] = `(GooglepubsubServerBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/http/HttpChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/http/HttpChannelBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements HttpChannelBindingElement should refract to semantic ApiDOM tree 1`] = `(HttpChannelBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/http/HttpMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/http/HttpMessageBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements HttpMessageBindingElement given query field of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (HttpMessageBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/http/HttpOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/http/HttpOperationBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements HttpOperationBindingElement given query field of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (HttpOperationBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/http/HttpServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/http/HttpServerBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements HttpServerBindingElement should refract to semantic ApiDOM tree 1`] = `(HttpServerBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ibmmq/IbmmqChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ibmmq/IbmmqChannelBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements IbmmqChannelBindingElement should refract to semantic ApiDOM tree 1`] = `
 (IbmmqChannelBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ibmmq/IbmmqMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ibmmq/IbmmqMessageBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements IbmmqMessageBindingElement should refract to semantic ApiDOM tree 1`] = `
 (IbmmqMessageBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ibmmq/IbmmqServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ibmmq/IbmmqServerBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements IbmmqServerBindingElement should refract to semantic ApiDOM tree 1`] = `
 (IbmmqServerBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ibmmq/ibmmqOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ibmmq/ibmmqOperationBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements IbmmqOperationBindingElement should refract to semantic ApiDOM tree 1`] = `(IbmmqOperationBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/jms/JmsChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/jms/JmsChannelBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements JmsChannelBindingElement should refract to semantic ApiDOM tree 1`] = `(JmsChannelBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/jms/JmsMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/jms/JmsMessageBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements JmsMessageBindingElement should refract to semantic ApiDOM tree 1`] = `(JmsMessageBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/jms/JmsOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/jms/JmsOperationBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements JmsOperationBindingElement should refract to semantic ApiDOM tree 1`] = `(JmsOperationBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/jms/JmsServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/jms/JmsServerBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements JmsServerBindingElement should refract to semantic ApiDOM tree 1`] = `(JmsServerBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/kafka/KafkaChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/kafka/KafkaChannelBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements KafkaChannelBindingElement should refract to semantic ApiDOM tree 1`] = `
 (KafkaChannelBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/kafka/KafkaMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/kafka/KafkaMessageBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements KafkaMessageBindingElement given query field of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (KafkaMessageBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/kafka/KafkaOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/kafka/KafkaOperationBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements KafkaOperationBindingElement given query field of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (KafkaOperationBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/kafka/KafkaServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/kafka/KafkaServerBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements KafkaServerBindingElement should refract to semantic ApiDOM tree 1`] = `
 (KafkaServerBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mercure/MercureChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mercure/MercureChannelBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements MercureChannelBindingElement should refract to semantic ApiDOM tree 1`] = `(MercureChannelBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mercure/MercureMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mercure/MercureMessageBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements MercureMessageBindingElement should refract to semantic ApiDOM tree 1`] = `(MercureMessageBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mercure/MercureOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mercure/MercureOperationBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements MercureOperationBindingElement should refract to semantic ApiDOM tree 1`] = `(MercureOperationBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mercure/MercureServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mercure/MercureServerBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements MercureServerBindingElement should refract to semantic ApiDOM tree 1`] = `(MercureServerBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt/MqttChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt/MqttChannelBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements MqttChannelBindingElement should refract to semantic ApiDOM tree 1`] = `(MqttChannelBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt/MqttMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt/MqttMessageBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements MqttMessageBindingElement should refract to semantic ApiDOM tree 1`] = `
 (MqttMessageBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt/MqttOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt/MqttOperationBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements MqttOperationBindingElement should refract to semantic ApiDOM tree 1`] = `
 (MqttOperationBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt/MqttServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt/MqttServerBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements MqttServerBindingElement should refract to semantic ApiDOM tree 1`] = `
 (MqttServerBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt5/Mqtt5ChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt5/Mqtt5ChannelBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements Mqtt5ChannelBindingElement should refract to semantic ApiDOM tree 1`] = `(Mqtt5ChannelBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt5/Mqtt5MessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt5/Mqtt5MessageBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements Mqtt5MessageBindingElement should refract to semantic ApiDOM tree 1`] = `(Mqtt5MessageBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt5/Mqtt5OperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt5/Mqtt5OperationBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements Mqtt5OperationBindingElement should refract to semantic ApiDOM tree 1`] = `(Mqtt5OperationBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt5/Mqtt5ServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/mqtt5/Mqtt5ServerBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements Mqtt5ServerBindingElement should refract to semantic ApiDOM tree 1`] = `(Mqtt5ServerBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/nats/NatsChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/nats/NatsChannelBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements NatsChannelBindingElement should refract to semantic ApiDOM tree 1`] = `(NatsChannelBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/nats/NatsMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/nats/NatsMessageBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements NatsMessageBindingElement should refract to semantic ApiDOM tree 1`] = `(NatsMessageBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/nats/NatsOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/nats/NatsOperationBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements NatsOperationBindingElement should refract to semantic ApiDOM tree 1`] = `
 (NatsOperationBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/nats/NatsServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/nats/NatsServerBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements NatsServerBindingElement should refract to semantic ApiDOM tree 1`] = `(NatsServerBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/pulsar/PulsarChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/pulsar/PulsarChannelBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements PulsarChannelBindingElement should refract to semantic ApiDOM tree 1`] = `
 (PulsarChannelBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/pulsar/PulsarMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/pulsar/PulsarMessageBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements PulsarMessageBindingElement should refract to semantic ApiDOM tree 1`] = `(PulsarMessageBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/pulsar/PulsarOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/pulsar/PulsarOperationBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements PulsarOperationBindingElement should refract to semantic ApiDOM tree 1`] = `(PulsarOperationBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/pulsar/PulsarServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/pulsar/PulsarServerBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements PulsarServerBindingElement should refract to semantic ApiDOM tree 1`] = `
 (PulsarServerBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/redis/RedisChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/redis/RedisChannelBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements RedisChannelBindingElement should refract to semantic ApiDOM tree 1`] = `(RedisChannelBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/redis/RedisMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/redis/RedisMessageBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements RedisMessageBindingElement should refract to semantic ApiDOM tree 1`] = `(RedisMessageBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/redis/RedisOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/redis/RedisOperationBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements RedisOperationBindingElement should refract to semantic ApiDOM tree 1`] = `(RedisOperationBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/redis/RedisServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/redis/RedisServerBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements RedisServerBindingElement should refract to semantic ApiDOM tree 1`] = `(RedisServerBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sns/SnsChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sns/SnsChannelBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SnsChannelBindingElement should refract to semantic ApiDOM tree 1`] = `(SnsChannelBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sns/SnsMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sns/SnsMessageBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SnsMessageBindingElement should refract to semantic ApiDOM tree 1`] = `(SnsMessageBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sns/SnsOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sns/SnsOperationBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SnsOperationBindingElement should refract to semantic ApiDOM tree 1`] = `(SnsOperationBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sns/SnsServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sns/SnsServerBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SnsServerBindingElement should refract to semantic ApiDOM tree 1`] = `(SnsServerBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/solace/SolaceChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/solace/SolaceChannelBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SolaceChannelBindingElement should refract to semantic ApiDOM tree 1`] = `(SolaceChannelBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/solace/SolaceMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/solace/SolaceMessageBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SolaceMessageBindingElement should refract to semantic ApiDOM tree 1`] = `(SolaceMessageBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/solace/SolaceOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/solace/SolaceOperationBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SolaceOperationBindingElement should refract to semantic ApiDOM tree 1`] = `
 (SolaceOperationBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/solace/SolaceServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/solace/SolaceServerBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SolaceServerBindingElement should refract to semantic ApiDOM tree 1`] = `
 (SolaceServerBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sqs/SqsChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sqs/SqsChannelBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SqsChannelBindingElement should refract to semantic ApiDOM tree 1`] = `(SqsChannelBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sqs/SqsMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sqs/SqsMessageBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SqsMessageBindingElement should refract to semantic ApiDOM tree 1`] = `(SqsMessageBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sqs/SqsOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sqs/SqsOperationBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SqsOperationBindingElement should refract to semantic ApiDOM tree 1`] = `(SqsOperationBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sqs/SqsServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/sqs/SqsServerBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SqsServerBindingElement should refract to semantic ApiDOM tree 1`] = `(SqsServerBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/stomp/StompChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/stomp/StompChannelBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements StompChannelBindingElement should refract to semantic ApiDOM tree 1`] = `(StompChannelBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/stomp/StompMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/stomp/StompMessageBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements StompMessageBindingElement should refract to semantic ApiDOM tree 1`] = `(StompMessageBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/stomp/StompOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/stomp/StompOperationBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements StompOperationBindingElement should refract to semantic ApiDOM tree 1`] = `(StompOperationBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/stomp/StompServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/stomp/StompServerBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements StompServerBindingElement should refract to semantic ApiDOM tree 1`] = `(StompServerBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ws/WebSocketChannelBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ws/WebSocketChannelBinding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements WebSocketChannelBindingElement given query and header fields of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (WebSocketChannelBindingElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ws/WebSocketMessageBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ws/WebSocketMessageBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements WebSocketMessageBindingElement should refract to semantic ApiDOM tree 1`] = `(WebSocketMessageBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ws/WebSocketOperationBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ws/WebSocketOperationBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements WebSocketOperationBindingElement should refract to semantic ApiDOM tree 1`] = `(WebSocketOperationBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ws/WebSocketServerBinding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/elements/bindings/ws/WebSocketServerBinding/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements WebSocketServerBindingElement should refract to semantic ApiDOM tree 1`] = `(WebSocketServerBindingElement)`;

--- a/packages/apidom-ns-asyncapi-2/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given AsyncAPI definition with no empty values should do nothing 1`] = `
 (AsyncApi2Element

--- a/packages/apidom-ns-asyncapi-2/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given empty value instead of OperationTraitElement should replace empty value with semantic element 1`] = `
 (AsyncApi2Element

--- a/packages/apidom-ns-asyncapi-2/test/refractor/plugins/replace-empty-element/elements/ChannelBindings/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/plugins/replace-empty-element/elements/ChannelBindings/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`should refract to semantic ApiDOM tree 1`] = `
 (ChannelBindingsElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/plugins/replace-empty-element/elements/MessageBindings/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/plugins/replace-empty-element/elements/MessageBindings/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`should refract to semantic ApiDOM tree 1`] = `
 (MessageBindingsElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/plugins/replace-empty-element/elements/OperationBindings/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/plugins/replace-empty-element/elements/OperationBindings/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`should refract to semantic ApiDOM tree 1`] = `
 (OperationBindingsElement

--- a/packages/apidom-ns-asyncapi-2/test/refractor/plugins/replace-empty-element/elements/ServerBindings/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-asyncapi-2/test/refractor/plugins/replace-empty-element/elements/ServerBindings/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`should refract to semantic ApiDOM tree 1`] = `
 (ServerBindingsElement

--- a/packages/apidom-ns-json-schema-2019-09/test/refractor/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-2019-09/test/refractor/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor given generic ApiDOM object in JSON Schema 2019-09 shape should refract to JSONSchema Element 1`] = `
 {

--- a/packages/apidom-ns-json-schema-2019-09/test/refractor/elements/JSONSchema/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-2019-09/test/refractor/elements/JSONSchema/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements Boolean JSON Schema support should refract to semantic ApiDOM tree 1`] = `
 {

--- a/packages/apidom-ns-json-schema-2019-09/test/refractor/elements/LinkDescription/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-2019-09/test/refractor/elements/LinkDescription/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements LinkDescription should refract to semantic ApiDOM tree 1`] = `
 (LinkDescriptionElement

--- a/packages/apidom-ns-json-schema-2019-09/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
+++ b/packages/apidom-ns-json-schema-2019-09/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given JSON Schema definition with no empty values should do nothing 1`] = `
 (JSONSchema201909Element

--- a/packages/apidom-ns-json-schema-2019-09/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
+++ b/packages/apidom-ns-json-schema-2019-09/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given JSON Schema definition with no empty values should do nothing 1`] = `
 (JSONSchema201909Element

--- a/packages/apidom-ns-json-schema-2020-12/test/refractor/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-2020-12/test/refractor/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor given generic ApiDOM object in JSON Schema 2020-12 shape should refract to JSONSchema Element 1`] = `
 {

--- a/packages/apidom-ns-json-schema-2020-12/test/refractor/elements/JSONSchema/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-2020-12/test/refractor/elements/JSONSchema/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements Boolean JSON Schema support should refract to semantic ApiDOM tree 1`] = `
 {

--- a/packages/apidom-ns-json-schema-2020-12/test/refractor/elements/LinkDescription/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-2020-12/test/refractor/elements/LinkDescription/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements LinkDescription should refract to semantic ApiDOM tree 1`] = `
 (LinkDescriptionElement

--- a/packages/apidom-ns-json-schema-2020-12/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
+++ b/packages/apidom-ns-json-schema-2020-12/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given JSON Schema definition with no empty values should do nothing 1`] = `
 (JSONSchema202012Element

--- a/packages/apidom-ns-json-schema-2020-12/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
+++ b/packages/apidom-ns-json-schema-2020-12/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given JSON Schema definition with no empty values should do nothing 1`] = `
 (JSONSchema202012Element

--- a/packages/apidom-ns-json-schema-draft-4/test/refractor/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-4/test/refractor/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor given generic ApiDOM object in JSON Schema Draft 4 shape should refract to JSONSchema Element 1`] = `
 {

--- a/packages/apidom-ns-json-schema-draft-4/test/refractor/elements/JSONReference/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-4/test/refractor/elements/JSONReference/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements JSONReference should refract to semantic ApiDOM tree 1`] = `
 (JSONReferenceElement

--- a/packages/apidom-ns-json-schema-draft-4/test/refractor/elements/JSONSchema/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-4/test/refractor/elements/JSONSchema/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements JSONSchema should refract to semantic ApiDOM tree 1`] = `
 (JSONSchemaDraft4Element

--- a/packages/apidom-ns-json-schema-draft-4/test/refractor/elements/LinkDescription/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-4/test/refractor/elements/LinkDescription/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements LinkDescription should refract to semantic ApiDOM tree 1`] = `
 (LinkDescriptionElement

--- a/packages/apidom-ns-json-schema-draft-4/test/refractor/elements/Media/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-4/test/refractor/elements/Media/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements Media should refract to semantic ApiDOM tree 1`] = `
 (MediaElement

--- a/packages/apidom-ns-json-schema-draft-4/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-4/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given JSON Schema definition with no empty values should do nothing 1`] = `
 (JSONSchemaDraft4Element

--- a/packages/apidom-ns-json-schema-draft-4/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-4/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given JSON Schema definition with no empty values should do nothing 1`] = `
 (JSONSchemaDraft4Element

--- a/packages/apidom-ns-json-schema-draft-6/test/refractor/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-6/test/refractor/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor given generic ApiDOM object in JSON Schema Draft 6 shape should refract to JSONSchema Element 1`] = `
 {

--- a/packages/apidom-ns-json-schema-draft-6/test/refractor/elements/JSONReference/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-6/test/refractor/elements/JSONReference/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements JSONReference should refract to semantic ApiDOM tree 1`] = `
 (JSONReferenceElement

--- a/packages/apidom-ns-json-schema-draft-6/test/refractor/elements/JSONSchema/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-6/test/refractor/elements/JSONSchema/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements Boolean JSON Schema support should refract to semantic ApiDOM tree 1`] = `
 {

--- a/packages/apidom-ns-json-schema-draft-6/test/refractor/elements/LinkDescription/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-6/test/refractor/elements/LinkDescription/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements LinkDescription should refract to semantic ApiDOM tree 1`] = `
 (LinkDescriptionElement

--- a/packages/apidom-ns-json-schema-draft-6/test/refractor/elements/Media/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-6/test/refractor/elements/Media/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements Media should refract to semantic ApiDOM tree 1`] = `
 (MediaElement

--- a/packages/apidom-ns-json-schema-draft-6/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-6/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given JSON Schema definition with no empty values should do nothing 1`] = `
 (JSONSchemaDraft6Element

--- a/packages/apidom-ns-json-schema-draft-6/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-6/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given JSON Schema definition with no empty values should do nothing 1`] = `
 (JSONSchemaDraft6Element

--- a/packages/apidom-ns-json-schema-draft-7/test/refractor/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-7/test/refractor/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor given generic ApiDOM object in JSON Schema Draft 7 shape should refract to JSONSchema Element 1`] = `
 {

--- a/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/JSONReference/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/JSONReference/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements JSONReference should refract to semantic ApiDOM tree 1`] = `
 (JSONReferenceElement

--- a/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/JSONSchema/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/JSONSchema/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements Boolean JSON Schema support should refract to semantic ApiDOM tree 1`] = `
 {

--- a/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/LinkDescription/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-7/test/refractor/elements/LinkDescription/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements LinkDescription should refract to semantic ApiDOM tree 1`] = `
 (LinkDescriptionElement

--- a/packages/apidom-ns-json-schema-draft-7/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-7/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given JSON Schema definition with no empty values should do nothing 1`] = `
 (JSONSchemaDraft7Element

--- a/packages/apidom-ns-json-schema-draft-7/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
+++ b/packages/apidom-ns-json-schema-draft-7/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given JSON Schema definition with no empty values should do nothing 1`] = `
 (JSONSchemaDraft7Element

--- a/packages/apidom-ns-openapi-2/test/refractor/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor given generic ApiDOM object in OpenAPI 2.0 shape should refract to SwaggerElement 1`] = `
 {

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Contact/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Contact/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ContactElement given generic ApiDOM element should refract to semantic ApiDOM tree 1`] = `
 (ContactElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Definitions/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Definitions/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements DefinitionsElement should refract to semantic ApiDOM tree 1`] = `
 (DefinitionsElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Example/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Example/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ExampleElement should refract to semantic ApiDOM tree 1`] = `
 (ExampleElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/ExternalDocumentation/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/ExternalDocumentation/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ExternalDocumentationElement should refract to semantic ApiDOM tree 1`] = `
 (ExternalDocumentationElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Header/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Header/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements HeaderElement should refract to semantic ApiDOM tree 1`] = `
 (HeaderElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Headers/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Headers/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements HeadersElement should refract to semantic ApiDOM tree 1`] = `
 (HeadersElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Info/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Info/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements InfoElement should refract to semantic ApiDOM tree 1`] = `
 (InfoElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Items/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Items/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ItemsElement should refract to semantic ApiDOM tree 1`] = `
 (ItemsElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/License/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/License/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements LicenseElement should refract to semantic ApiDOM tree 1`] = `
 (LicenseElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Operation/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Operation/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OperationElement should refract to semantic ApiDOM tree 1`] = `
 (OperationElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Parameter/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Parameter/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ParameterElement given schema keyword in form of object with $ref property should refract to semantic ApiDOM tree 1`] = `
 (ParameterElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/ParametersDefinitions/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/ParametersDefinitions/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ParametersDefinitionsElement should refract to semantic ApiDOM tree 1`] = `
 (ParametersDefinitionsElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/PathItem/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/PathItem/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements PathItemElement should refract to semantic ApiDOM tree 1`] = `
 (PathItemElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Paths/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Paths/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements PathsElement should refract to semantic ApiDOM tree 1`] = `
 (PathsElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Reference/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Reference/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (ReferenceElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Response/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Response/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ResponseElement given schema keyword in form of object with $ref property should refract to semantic ApiDOM tree 1`] = `
 (ResponseElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Responses/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Responses/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ResponsesElement given all fields of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (ResponsesElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/ResponsesDefinitions/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/ResponsesDefinitions/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ResponsesDefinitionsElement should refract to semantic ApiDOM tree 1`] = `
 (ResponsesDefinitionsElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Schema/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Schema/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SchemaElement given allOf keyword with reference should refract to semantic ApiDOM tree 1`] = `
 (SchemaElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Scopes/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Scopes/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ScopesElement should refract to semantic ApiDOM tree 1`] = `
 (ScopesElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/SecurityDefinitions/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/SecurityDefinitions/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SecurityDefinitionsElement should refract to semantic ApiDOM tree 1`] = `
 (SecurityDefinitionsElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/SecurityRequirement/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/SecurityRequirement/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SecurityRequirementElement should refract to semantic ApiDOM tree 1`] = `
 (SecurityRequirementElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/SecurityScheme/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/SecurityScheme/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SecuritySchemeElement should refract to semantic ApiDOM tree 1`] = `
 (SecuritySchemeElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Swagger/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Swagger/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SwaggerElement should refract to semantic ApiDOM tree 1`] = `
 (SwaggerElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Tag/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Tag/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements TagElement should refract to semantic ApiDOM tree 1`] = `
 (TagElement

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Xml/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Xml/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements XmlElement should refract to semantic ApiDOM tree 1`] = `
 (XmlElement

--- a/packages/apidom-ns-openapi-2/test/refractor/plugins/normalize-parameters/__snapshots__/idempotence.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/plugins/normalize-parameters/__snapshots__/idempotence.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-parameters should have idempotent characteristics 1`] = `
 Object {

--- a/packages/apidom-ns-openapi-2/test/refractor/plugins/normalize-parameters/paths/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/plugins/normalize-parameters/paths/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-parameters given parameters are defined in Path Item Object and Operation Object defines additional parameter should merge with all Path Item parameters 1`] = `
 (SwaggerElement

--- a/packages/apidom-ns-openapi-2/test/refractor/plugins/normalize-security-requirements/__snapshots__/idempotence.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/plugins/normalize-security-requirements/__snapshots__/idempotence.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-security-requirements should have idempotent characteristics 1`] = `
 Object {

--- a/packages/apidom-ns-openapi-2/test/refractor/plugins/normalize-security-requirements/paths/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/plugins/normalize-security-requirements/paths/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-security-requirements given Swagger.security fixed field is defined and Operation.security contains single Security Requirement should not inherit Security Requirements from Swagger.security field 1`] = `
 (SwaggerElement

--- a/packages/apidom-ns-openapi-2/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given OpenAPI definition with no empty values should do nothing 1`] = `
 (SwaggerElement

--- a/packages/apidom-ns-openapi-2/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
+++ b/packages/apidom-ns-openapi-2/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given empty value instead of SecurityRequirementElement should replace empty value with semantic element 1`] = `
 (SwaggerElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor given generic ApiDOM object in OpenApi 3.0.4 shape should refract to OpenApi 3.0 Element 1`] = `
 {

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Callback/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Callback/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements CallbackElement should refract to semantic ApiDOM tree 1`] = `
 (CallbackElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Components/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Components/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ComponentsElement should refract to semantic ApiDOM tree 1`] = `
 (ComponentsElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Contact/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Contact/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ContactElement should refract to semantic ApiDOM tree 1`] = `
 (ContactElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Discriminator/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Discriminator/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements DiscriminatorElement should refract to semantic ApiDOM tree 1`] = `
 (DiscriminatorElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Encoding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Encoding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements EncodingElement should refract to semantic ApiDOM tree 1`] = `
 (EncodingElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Example/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Example/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ExampleElement should refract to semantic ApiDOM tree 1`] = `
 (ExampleElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/ExternalDocumentation/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/ExternalDocumentation/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ExternalDocumentationElement should refract to semantic ApiDOM tree 1`] = `
 (ExternalDocumentationElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Header/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Header/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements HeaderElement should refract to semantic ApiDOM tree 1`] = `
 (HeaderElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Info/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Info/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements InfoElement given generic ApiDOM element should refract to semantic ApiDOM tree 1`] = `(InfoElement)`;
 

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/License/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/License/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements LicenseElement should refract to semantic ApiDOM tree 1`] = `
 (LicenseElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Link/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Link/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements LinkElement should refract to semantic ApiDOM tree 1`] = `
 (LinkElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/MediaType/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/MediaType/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements MediaTypeElement should refract to semantic ApiDOM tree 1`] = `
 (MediaTypeElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/OAuthFlow/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/OAuthFlow/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OAuthFlowElement should refract to semantic ApiDOM tree 1`] = `
 (OAuthFlowElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/OAuthFlows/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/OAuthFlows/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OAuthFlowsElement should refract to semantic ApiDOM tree 1`] = `
 (OAuthFlowsElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/OpenApi3-0/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/OpenApi3-0/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OpenApi3_0Element should refract OpenAPI 3.0.0 to semantic ApiDOM tree 1`] = `
 (OpenApi3_0Element

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Openapi/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Openapi/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OpenapiElement 3.0.0 should refract to semantic ApiDOM tree 1`] = `(OpenapiElement)`;
 

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Operation/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Operation/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OperationElement given requestBody field of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (OperationElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Parameter/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Parameter/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ParameterElement should refract to semantic ApiDOM tree 1`] = `
 (ParameterElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/PathItem/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/PathItem/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements PathItemElement should refract to semantic ApiDOM tree 1`] = `
 (PathItemElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Paths/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Paths/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements PathsElement should refract to semantic ApiDOM tree 1`] = `
 (PathsElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Reference/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Reference/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (ReferenceElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/RequestBody/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/RequestBody/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements RequestBodyElement should refract to semantic ApiDOM tree 1`] = `
 (RequestBodyElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Response/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Response/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ResponseElement should refract to semantic ApiDOM tree 1`] = `
 (ResponseElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Responses/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Responses/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ResponsesElement given all fields of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (ResponsesElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Schema/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Schema/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SchemaElement given allOf keyword with reference should refract to semantic ApiDOM tree 1`] = `
 (SchemaElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/SecurityRequirement/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/SecurityRequirement/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SecurityRequirementElement should refract to semantic ApiDOM tree 1`] = `
 (SecurityRequirementElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/SecurityScheme/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/SecurityScheme/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SecuritySchemeElement should refract to semantic ApiDOM tree 1`] = `
 (SecuritySchemeElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Server/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Server/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ServerElement should refract to semantic ApiDOM tree 1`] = `
 (ServerElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/ServerVariable/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/ServerVariable/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ServerVariableElement should refract to semantic ApiDOM tree 1`] = `
 (ServerVariableElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Tag/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Tag/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements TagElement should refract to semantic ApiDOM tree 1`] = `
 (TagElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Xml/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Xml/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements XmlElement should refract to semantic ApiDOM tree 1`] = `
 (XmlElement

--- a/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-parameters/__snapshots__/idempotence.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-parameters/__snapshots__/idempotence.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-parameters should have idempotent characteristics 1`] = `
 Object {

--- a/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-parameters/callbacks/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-parameters/callbacks/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-parameters given parameters are defined in Path Item Object and Operation Object defines additional parameter should merge with all parameters from closest Path Item 1`] = `
 (OpenApi3_0Element

--- a/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-parameters/components/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-parameters/components/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-parameters given Path Item Object is defined in Components.callbacks should skip the Path Item from normalization 1`] = `
 (OpenApi3_0Element

--- a/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-parameters/paths/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-parameters/paths/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-parameters given parameters are defined in Path Item Object and Operation Object defines additional parameter should merge with all Path Item parameters 1`] = `
 (OpenApi3_0Element

--- a/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-security-requirements/__snapshots__/idempotence.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-security-requirements/__snapshots__/idempotence.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-security-requirements should have idempotent characteristics 1`] = `
 Object {

--- a/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-security-requirements/callbacks/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-security-requirements/callbacks/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-security-requirements given OpenAPI.security fixed field is defined and Operation.security contains single Security Requirement should not inherit Security Requirements from OpenAPI.security field 1`] = `
 (OpenApi3_0Element

--- a/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-security-requirements/components/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-security-requirements/components/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-security-requirements given Operation Object is defined in Components.callbacks should skip the Operation from normalization 1`] = `
 (OpenApi3_0Element

--- a/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-security-requirements/paths/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-security-requirements/paths/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-security-requirements given OpenAPI.security fixed field is defined and Operation.security contains single Security Requirement should not inherit Security Requirements from OpenAPI.security field 1`] = `
 (OpenApi3_0Element

--- a/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-servers/__snapshots__/idempotence.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-servers/__snapshots__/idempotence.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-servers should have idempotent characteristics 1`] = `
 Object {

--- a/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-servers/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-servers/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-servers given OpenAPI.servers defined and PathItem.servers defined should duplicate Server Objects from PathItem.servers 1`] = `
 {

--- a/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-servers/components/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-servers/components/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-servers given Path Item Object is defined in Components.callbacks should skip the Path Item from normalization 1`] = `
 (OpenApi3_0Element

--- a/packages/apidom-ns-openapi-3-0/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given OpenAPI definition with no empty values should do nothing 1`] = `
 (OpenApi3_0Element

--- a/packages/apidom-ns-openapi-3-0/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given empty value instead of SecurityRequirementElement should replace empty value with semantic element 1`] = `
 (OpenApi3_0Element

--- a/packages/apidom-ns-openapi-3-1/test/refractor/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor given generic ApiDOM object in OpenApi 3.1 shape should refract to OpenApi 3.1 Element 1`] = `
 {

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Callback/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Callback/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements CallbackElement should refract to semantic ApiDOM tree 1`] = `
 (CallbackElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Components/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Components/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ComponentsElement should refract to semantic ApiDOM tree 1`] = `
 (ComponentsElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Contact/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Contact/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ContactElement should refract to semantic ApiDOM tree 1`] = `
 (ContactElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Discriminator/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Discriminator/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements DiscriminatorElement should refract to semantic ApiDOM tree 1`] = `
 (DiscriminatorElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Encoding/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Encoding/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements EncodingElement should refract to semantic ApiDOM tree 1`] = `
 (EncodingElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Example/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Example/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ExampleElement should refract to semantic ApiDOM tree 1`] = `
 (ExampleElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/ExternalDocumentation/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/ExternalDocumentation/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ExternalDocumentationElement should refract to semantic ApiDOM tree 1`] = `
 (ExternalDocumentationElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Header/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Header/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements HeaderElement should refract to semantic ApiDOM tree 1`] = `
 (HeaderElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Info/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Info/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements InfoElement given generic ApiDOM element should refract to semantic ApiDOM tree 1`] = `(InfoElement)`;
 

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/JsonSchemaDialect/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/JsonSchemaDialect/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements JsonSchemaDialectElement should refract to semantic ApiDOM tree 1`] = `(JsonSchemaDialectElement)`;

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/License/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/License/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements LicenseElement should refract to semantic ApiDOM tree 1`] = `
 (LicenseElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Link/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Link/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements LinkElement should refract to semantic ApiDOM tree 1`] = `
 (LinkElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/MediaType/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/MediaType/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements MediaTypeElement should refract to semantic ApiDOM tree 1`] = `
 (MediaTypeElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/OAuthFlow/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/OAuthFlow/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OAuthFlowElement should refract to semantic ApiDOM tree 1`] = `
 (OAuthFlowElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/OAuthFlows/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/OAuthFlows/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OAuthFlowsElement should refract to semantic ApiDOM tree 1`] = `
 (OAuthFlowsElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/OpenApi3-1/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/OpenApi3-1/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OpenApi3_1Element should refract to semantic ApiDOM tree 1`] = `
 (OpenApi3_1Element

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Openapi/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Openapi/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OpenapiElement should refract to semantic ApiDOM tree 1`] = `(OpenapiElement)`;

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Operation/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Operation/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OperationElement given requestBody field of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (OperationElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Parameter/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Parameter/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ParameterElement should refract to semantic ApiDOM tree 1`] = `
 (ParameterElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/PathItem/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/PathItem/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements PathItemElement should refract to semantic ApiDOM tree 1`] = `
 (PathItemElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Paths/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Paths/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements PathsElement should refract to semantic ApiDOM tree 1`] = `
 (PathsElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Reference/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Reference/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (ReferenceElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/RequestBody/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/RequestBody/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements RequestBodyElement should refract to semantic ApiDOM tree 1`] = `
 (RequestBodyElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Response/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Response/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ResponseElement should refract to semantic ApiDOM tree 1`] = `
 (ResponseElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Responses/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Responses/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ResponsesElement given all fields of type ReferenceElement should refract to semantic ApiDOM tree 1`] = `
 (ResponsesElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Schema/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Schema/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SchemaElement given Boolean JSON Schemas should refract to semantic ApiDOM tree 1`] = `
 (SchemaElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/SecurityRequirement/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/SecurityRequirement/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SecurityRequirementElement should refract to semantic ApiDOM tree 1`] = `
 (SecurityRequirementElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/SecurityScheme/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/SecurityScheme/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements SecuritySchemeElement should refract to semantic ApiDOM tree 1`] = `
 (SecuritySchemeElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Server/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Server/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ServerElement should refract to semantic ApiDOM tree 1`] = `
 (ServerElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/ServerVariable/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/ServerVariable/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ServerVariableElement should refract to semantic ApiDOM tree 1`] = `
 (ServerVariableElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Tag/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Tag/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements TagElement should refract to semantic ApiDOM tree 1`] = `
 (TagElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/elements/Xml/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/elements/Xml/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements XmlElement should refract to semantic ApiDOM tree 1`] = `
 (XmlElement

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-header-examples/__snapshots__/idempotence.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-header-examples/__snapshots__/idempotence.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-header-examples should have idempotent characteristics 1`] = `
 Object {

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-header-examples/components/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-header-examples/components/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-header-examples given Header Object is defined in Components.headers should skip the Header Object from normalization 1`] = `
 Object {

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-header-examples/paths/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-header-examples/paths/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-header-examples given Header Object defines both example and examples field and Schema Object defines both example and examples fields should override both Schema Object example and examples fields 1`] = `
 Object {

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-operation-ids/__snapshots__/idempotence.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-operation-ids/__snapshots__/idempotence.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-parameters should have idempotent characteristics 1`] = `
 Object {

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-operation-ids/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-operation-ids/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-operation-ids given Operation Object with missing operationId field should not normalize operationId 1`] = `
 {

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameter-examples/__snapshots__/idempotence.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameter-examples/__snapshots__/idempotence.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-parameter-examples should have idempotent characteristics 1`] = `
 Object {

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameter-examples/components/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameter-examples/components/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-parameter-examples given Parameter Object is defined in Components.parameters should skip the Parameter Object from normalization 1`] = `
 Object {

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameter-examples/paths/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameter-examples/paths/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-parameter-examples given Parameter Object defines both example and examples field and Schema Object defines both example and examples fields should override both Schema Object example and examples fields 1`] = `
 Object {

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/__snapshots__/idempotence.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/__snapshots__/idempotence.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-parameters should have idempotent characteristics 1`] = `
 Object {

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/callbacks/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/callbacks/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-parameters given parameters are defined in Path Item Object and Operation Object defines additional parameter should merge with all parameters from closest Path Item 1`] = `
 (OpenApi3_1Element

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/components/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/components/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-parameters given Path Item Object is defined in Components.callbacks should skip the Path Item from normalization 1`] = `
 (OpenApi3_1Element

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/paths/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/paths/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-parameters given parameters are defined in Path Item Object and Operation Object defines additional parameter should merge with all Path Item parameters 1`] = `
 (OpenApi3_1Element

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/web-hooks/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/web-hooks/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-parameters given parameters are defined in Path Item Object and Operation Object defines additional parameter should merge with all Path Item parameters 1`] = `
 (OpenApi3_1Element

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-security-requirements/__snapshots__/idempotence.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-security-requirements/__snapshots__/idempotence.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-security-requirements should have idempotent characteristics 1`] = `
 Object {

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-security-requirements/callbacks/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-security-requirements/callbacks/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-security-requirements given OpenAPI.security fixed field is defined and Operation.security contains single Security Requirement should not inherit Security Requirements from OpenAPI.security field 1`] = `
 (OpenApi3_1Element

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-security-requirements/components/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-security-requirements/components/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-security-requirements given Operation Object is defined in Components.callbacks should skip the Operation from normalization 1`] = `
 (OpenApi3_1Element

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-security-requirements/paths/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-security-requirements/paths/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-security-requirements given OpenAPI.security fixed field is defined and Operation.security contains single Security Requirement should not inherit Security Requirements from OpenAPI.security field 1`] = `
 (OpenApi3_1Element

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-security-requirements/webhooks/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-security-requirements/webhooks/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-security-requirements given OpenAPI.security fixed field is defined and Operation.security contains single Security Requirement should not inherit Security Requirements from OpenAPI.security field 1`] = `
 (OpenApi3_1Element

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-servers/__snapshots__/idempotence.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-servers/__snapshots__/idempotence.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-servers should have idempotent characteristics 1`] = `
 Object {

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-servers/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-servers/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-servers given OpenAPI.servers defined and PathItem.servers defined should duplicate Server Objects from PathItem.servers 1`] = `
 {

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-servers/components/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-servers/components/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor plugins normalize-servers given Path Item Object is defined in Components.callbacks should skip the Path Item from normalization 1`] = `
 (OpenApi3_1Element

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given OpenAPI definition with no empty values should do nothing 1`] = `
 (OpenApi3_1Element

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given empty value instead of SecurityRequirementElement should replace empty value with semantic element 1`] = `
 (OpenApi3_1Element

--- a/packages/apidom-ns-overlay-1/test/refractor/elements/Action/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-overlay-1/test/refractor/elements/Action/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements ActionElement given action with copy field should refract to semantic ApiDOM tree 1`] = `
 (ActionElement

--- a/packages/apidom-ns-overlay-1/test/refractor/elements/Info/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-overlay-1/test/refractor/elements/Info/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements InfoElement given generic ApiDOM element should refract to semantic ApiDOM tree 1`] = `(InfoElement)`;
 

--- a/packages/apidom-ns-overlay-1/test/refractor/elements/Overlay/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-overlay-1/test/refractor/elements/Overlay/__snapshots__/index.mjs.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements OverlayElement should refract to semantic ApiDOM tree 1`] = `(OverlayElement)`;

--- a/packages/apidom-ns-overlay-1/test/refractor/elements/Overlay1/__snapshots__/index.mjs.snap
+++ b/packages/apidom-ns-overlay-1/test/refractor/elements/Overlay1/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`refractor elements Overlay1Element should refract to semantic ApiDOM tree 1`] = `
 (Overlay1Element

--- a/packages/apidom-ns-overlay-1/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
+++ b/packages/apidom-ns-overlay-1/test/refractor/plugins/replace-empty-element/__snapshots__/mappings.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given empty value instead of Actions should replace empty value with semantic element 1`] = `
 (Overlay1Element

--- a/packages/apidom-ns-overlay-1/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
+++ b/packages/apidom-ns-overlay-1/test/refractor/plugins/replace-empty-element/__snapshots__/sequences.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`given empty value instead of ActionElement should replace empty value with semantic element 1`] = `
 (Overlay1Element

--- a/packages/apidom-overlay/test/apply/realms/__snapshots__/apidom.mjs.snap
+++ b/packages/apidom-overlay/test/apply/realms/__snapshots__/apidom.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`applyOverlayApiDOM realistic overlay scenario should produce correct result 1`] = `
 {

--- a/packages/apidom-overlay/test/apply/realms/__snapshots__/uri.mjs.snap
+++ b/packages/apidom-overlay/test/apply/realms/__snapshots__/uri.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`applyOverlay (URI-level) given JSON target via extends should preserve JSON formatting 1`] = `
 {

--- a/packages/apidom-parser-adapter-arazzo-json-1/test/__snapshots__/adapter.mjs.snap
+++ b/packages/apidom-parser-adapter-arazzo-json-1/test/__snapshots__/adapter.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter should parse 1`] = `
 (ParseResultElement

--- a/packages/apidom-parser-adapter-arazzo-yaml-1/test/__snapshots__/adapter.mjs.snap
+++ b/packages/apidom-parser-adapter-arazzo-yaml-1/test/__snapshots__/adapter.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter should parse 1`] = `
 (ParseResultElement

--- a/packages/apidom-parser-adapter-asyncapi-json-2/test/__snapshots__/adapter.mjs.snap
+++ b/packages/apidom-parser-adapter-asyncapi-json-2/test/__snapshots__/adapter.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter should parse 1`] = `
 (ParseResultElement

--- a/packages/apidom-parser-adapter-asyncapi-yaml-2/test/__snapshots__/adapter.mjs.snap
+++ b/packages/apidom-parser-adapter-asyncapi-yaml-2/test/__snapshots__/adapter.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter should parse 1`] = `
 (ParseResultElement

--- a/packages/apidom-parser-adapter-json-schema-json-2020-12/test/__snapshots__/adapter.mjs.snap
+++ b/packages/apidom-parser-adapter-json-schema-json-2020-12/test/__snapshots__/adapter.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter should parse 1`] = `
 (ParseResultElement

--- a/packages/apidom-parser-adapter-json-schema-yaml-2020-12/test/__snapshots__/adapter.mjs.snap
+++ b/packages/apidom-parser-adapter-json-schema-yaml-2020-12/test/__snapshots__/adapter.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter should parse 1`] = `
 (ParseResultElement

--- a/packages/apidom-parser-adapter-json/test/__snapshots__/adapter.mjs.snap
+++ b/packages/apidom-parser-adapter-json/test/__snapshots__/adapter.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter should parse 1`] = `
 (ParseResultElement

--- a/packages/apidom-parser-adapter-openapi-json-2/test/__snapshots__/adapter.mjs.snap
+++ b/packages/apidom-parser-adapter-openapi-json-2/test/__snapshots__/adapter.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter should parse 1`] = `
 (ParseResultElement

--- a/packages/apidom-parser-adapter-openapi-json-3-0/test/__snapshots__/adapter.mjs.snap
+++ b/packages/apidom-parser-adapter-openapi-json-3-0/test/__snapshots__/adapter.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter should parse 1`] = `
 (ParseResultElement

--- a/packages/apidom-parser-adapter-openapi-json-3-1/test/__snapshots__/adapter.mjs.snap
+++ b/packages/apidom-parser-adapter-openapi-json-3-1/test/__snapshots__/adapter.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter should parse 1`] = `
 (ParseResultElement

--- a/packages/apidom-parser-adapter-openapi-yaml-2/test/__snapshots__/adapter.mjs.snap
+++ b/packages/apidom-parser-adapter-openapi-yaml-2/test/__snapshots__/adapter.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter should parse 1`] = `
 (ParseResultElement

--- a/packages/apidom-parser-adapter-openapi-yaml-3-0/test/__snapshots__/adapter.mjs.snap
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-0/test/__snapshots__/adapter.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter should parse 1`] = `
 (ParseResultElement

--- a/packages/apidom-parser-adapter-openapi-yaml-3-1/test/__snapshots__/adapter.mjs.snap
+++ b/packages/apidom-parser-adapter-openapi-yaml-3-1/test/__snapshots__/adapter.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter should parse 1`] = `
 (ParseResultElement

--- a/packages/apidom-parser-adapter-overlay-json-1/test/__snapshots__/adapter.mjs.snap
+++ b/packages/apidom-parser-adapter-overlay-json-1/test/__snapshots__/adapter.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter should parse 1`] = `
 (ParseResultElement

--- a/packages/apidom-parser-adapter-overlay-yaml-1/test/__snapshots__/adapter.mjs.snap
+++ b/packages/apidom-parser-adapter-overlay-yaml-1/test/__snapshots__/adapter.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter should parse 1`] = `
 (ParseResultElement

--- a/packages/apidom-parser-adapter-yaml-1-2/test/adapter/__snapshots__/index.mjs.snap
+++ b/packages/apidom-parser-adapter-yaml-1-2/test/adapter/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`adapter given valid YAML 1.2 with very long mapping key should parse 1`] = `
 Array [

--- a/packages/apidom-reference/test/dereference/strategies/arazzo-1/source-descriptions/__snapshots__/index.mjs.snap
+++ b/packages/apidom-reference/test/dereference/strategies/arazzo-1/source-descriptions/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`dereference strategies arazzo-1 sourceDescriptions given sourceDescriptions enabled should dereference source description document 1`] = `
 {

--- a/packages/apidom-reference/test/dereference/strategies/overlay-1/extends/__snapshots__/index.mjs.snap
+++ b/packages/apidom-reference/test/dereference/strategies/overlay-1/extends/__snapshots__/index.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`dereference strategies overlay-1 extends given extends enabled should dereference $refs in the extends target document 1`] = `
 {


### PR DESCRIPTION
## Summary

Eliminates all 17 ERESOLVE peer dependency warnings that appeared during `npm install` by adding targeted npm overrides to align the dependency tree with Babel 8.

## Changes

- Upgraded `jest-snapshot` from 29.7.0 to 30.4.1 (latest)
- Added overrides to force Babel 8 for:
  - `@babel/core` (references devDependency version 8.0.1)
  - `@babel/plugin-syntax-jsx` (8.0.0)
  - `@babel/plugin-syntax-typescript` (8.0.0)

## Context

After upgrading to Babel 8 in PR #354, `npm install` produced 17 warnings about peer dependency conflicts. The warnings occurred because `jest-snapshot@29.7.0` and its transitive dependencies (`babel-preset-current-node-syntax`, various `@babel/plugin-syntax-*` packages) expected Babel 7.

The overrides force compatible versions throughout the dependency tree, allowing:
- The project build to use Babel 8 
- jest-snapshot's internal operations to work with Babel 8 or isolated Babel 7 dependencies

## Test Plan

- ✅ `npm install` completes with zero ERESOLVE warnings
- ✅ Babel 8 builds work (`npm run build:es` in apidom-core)
- ✅ All 166 tests pass in apidom-core
- ✅ Snapshot testing works correctly with jest-snapshot@30.4.1

## Breaking Changes

None. This is a devDependency-only change that fixes warnings without affecting runtime behavior or public API.