### PR TITLE
chore(reference): upgrade arazzo-runtime-expression to v3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9180,6 +9180,18 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@swaggerexpert/arazzo-runtime-expression": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@swaggerexpert/arazzo-runtime-expression/-/arazzo-runtime-expression-3.0.0.tgz",
+      "integrity": "sha512-ppOPKm/et4XXtyfDZpZEcUoyT9CQnuUFJjjZuLTD6/UL68aEXX3Y8ufPVyqz7q8eciGvSxJ1ZpXr9jtq4cHIPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "apg-lite": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=16.14.0"
+      }
+    },
     "node_modules/@swaggerexpert/json-pointer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@swaggerexpert/json-pointer/-/json-pointer-3.0.1.tgz",
@@ -27072,7 +27084,7 @@
         "@speclynx/apidom-parser-adapter-overlay-yaml-1": "4.16.0",
         "@speclynx/apidom-parser-adapter-yaml-1-2": "4.16.0",
         "@speclynx/apidom-traverse": "4.16.0",
-        "@swaggerexpert/arazzo-runtime-expression": "^2.0.3",
+        "@swaggerexpert/arazzo-runtime-expression": "^3.0.0",
         "axios": "^1.18.0",
         "picomatch": "^4.0.4",
         "process": "^0.11.10",
@@ -27082,18 +27094,6 @@
       "devDependencies": {
         "@types/picomatch": "^4.0.3",
         "axios-mock-adapter": "^2.0.0"
-      }
-    },
-    "packages/apidom-reference/node_modules/@swaggerexpert/arazzo-runtime-expression": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@swaggerexpert/arazzo-runtime-expression/-/arazzo-runtime-expression-2.0.3.tgz",
-      "integrity": "sha512-iGzCT3a6edX/LyQFhaR5l1JEyGtCQArGVjKDk8T7biaz24TE3CgDUMyeWzhGq9x7GBDj6KsxkI1WKEdERiDT5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "apg-lite": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=16.14.0"
       }
     },
     "packages/apidom-reference/node_modules/agent-base": {

--- a/packages/apidom-reference/package.json
+++ b/packages/apidom-reference/package.json
@@ -325,7 +325,7 @@
     "@speclynx/apidom-parser-adapter-overlay-yaml-1": "4.16.0",
     "@speclynx/apidom-parser-adapter-yaml-1-2": "4.16.0",
     "@speclynx/apidom-traverse": "4.16.0",
-    "@swaggerexpert/arazzo-runtime-expression": "^2.0.3",
+    "@swaggerexpert/arazzo-runtime-expression": "^3.0.0",
     "axios": "^1.18.0",
     "picomatch": "^4.0.4",
     "process": "^0.11.10",

--- a/packages/apidom-reference/src/dereference/strategies/arazzo-1/visitor.ts
+++ b/packages/apidom-reference/src/dereference/strategies/arazzo-1/visitor.ts
@@ -270,7 +270,7 @@ class Arazzo1DereferenceVisitor {
     }
 
     // evaluate runtime expression as JSON Pointer to get the referenced element
-    const jsonPointer = jsonPointerCompile(['components', tree.field, tree.subField]);
+    const jsonPointer = jsonPointerCompile(['components', tree.componentType, tree.componentName]);
     let referencedElement: Element;
     try {
       referencedElement = jsonPointerEvaluate<Element>(


### PR DESCRIPTION
## Summary

Upgrades `@swaggerexpert/arazzo-runtime-expression` from `^2.0.3` to `^3.0.0` in the `apidom-reference` package.

## Changes

- **packages/apidom-reference/package.json** — Updated dependency version to `^3.0.0`
- **packages/apidom-reference/src/dereference/strategies/arazzo-1/visitor.ts** — Adapted to v3 API changes

## Breaking change in v3

The parse result tree structure for `ComponentsExpression` changed:

**v2:**
```json
{
  "type": "ComponentsExpression",
  "field": "parameters",
  "subField": "authToken"
}
```

**v3:**
```json
{
  "type": "ComponentsExpression",
  "componentType": "parameters",
  "componentName": "authToken"
}
```

Updated the visitor code to use `tree.componentType` and `tree.componentName` instead of `tree.field` and `tree.subField`.

## Test results

✅ All 1500 tests passing, including the 7 arazzo-1 reusable object tests that were failing before the fix.