### PR TITLE
fix(ns-arazzo-1): tag JSON Schema refs with own element name

### DIFF
--- a/packages/apidom-ns-arazzo-1/src/refractor/visitors/arazzo-1/json-schema/index.ts
+++ b/packages/apidom-ns-arazzo-1/src/refractor/visitors/arazzo-1/json-schema/index.ts
@@ -1,3 +1,5 @@
+import { ObjectElement, isStringElement } from '@speclynx/apidom-datamodel';
+import { Path } from '@speclynx/apidom-traverse';
 import {
   JSONSchemaVisitor as JSONSchema202012Visitor,
   JSONSchemaVisitorOptions,
@@ -16,6 +18,16 @@ class JSONSchemaVisitor extends JSONSchema202012Visitor {
   constructor(options: JSONSchemaVisitorOptions) {
     super(options);
     this.element = new JSONSchemaElement();
+  }
+
+  ObjectElement(path: Path<ObjectElement>) {
+    super.ObjectElement(path);
+
+    // the inherited visitor tags `schema`, which no Arazzo element is named;
+    // consumers match this value against an element name, so mirror our own
+    if (isStringElement(this.element.$ref)) {
+      this.element.meta.set('referenced-element', this.element.element);
+    }
   }
 }
 

--- a/packages/apidom-ns-arazzo-1/src/refractor/visitors/arazzo-1/json-schema/index.ts
+++ b/packages/apidom-ns-arazzo-1/src/refractor/visitors/arazzo-1/json-schema/index.ts
@@ -1,4 +1,4 @@
-import { ObjectElement, isStringElement } from '@speclynx/apidom-datamodel';
+import { ObjectElement } from '@speclynx/apidom-datamodel';
 import { Path } from '@speclynx/apidom-traverse';
 import {
   JSONSchemaVisitor as JSONSchema202012Visitor,
@@ -25,7 +25,7 @@ class JSONSchemaVisitor extends JSONSchema202012Visitor {
 
     // the inherited visitor tags `schema`, which no Arazzo element is named;
     // consumers match this value against an element name, so mirror our own
-    if (isStringElement(this.element.$ref)) {
+    if (this.element.meta.hasKey('referenced-element')) {
       this.element.meta.set('referenced-element', this.element.element);
     }
   }

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/ArazzoSpecification1/index.ts
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/ArazzoSpecification1/index.ts
@@ -1,7 +1,9 @@
-import { expect } from 'chai';
-import { sexprs } from '@speclynx/apidom-core';
+import { assert, expect } from 'chai';
+import { sexprs, toValue } from '@speclynx/apidom-core';
+import { isStringElement } from '@speclynx/apidom-datamodel';
+import { find } from '@speclynx/apidom-traverse';
 
-import { refractArazzoSpecification1 } from '../../../../src/index.ts';
+import { isJSONSchemaElement, refractArazzoSpecification1 } from '../../../../src/index.ts';
 
 describe('refractor', function () {
   context('elements', function () {
@@ -16,6 +18,27 @@ describe('refractor', function () {
         });
 
         expect(sexprs(arazzoSpecification1Element)).toMatchSnapshot();
+      });
+
+      context('given Workflow Object inputs with $ref', function () {
+        specify('should contain referenced-element meta', function () {
+          const arazzoSpecification1Element = refractArazzoSpecification1({
+            arazzo: '1.0.1',
+            info: {},
+            sourceDescriptions: [{}],
+            workflows: [{ workflowId: 'wf', inputs: { $ref: '#/components/inputs/input1' } }],
+            components: { inputs: { input1: {} } },
+          });
+          const referencingElement = find(
+            arazzoSpecification1Element,
+            (path) => isJSONSchemaElement(path.node) && isStringElement(path.node.$ref),
+          )?.node;
+
+          assert.strictEqual(
+            toValue(referencingElement!.meta.get('referenced-element')),
+            'JSONSchema',
+          );
+        });
       });
     });
   });

--- a/packages/apidom-ns-arazzo-1/test/refractor/elements/JSONSchema/index.ts
+++ b/packages/apidom-ns-arazzo-1/test/refractor/elements/JSONSchema/index.ts
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
-import { sexprs } from '@speclynx/apidom-core';
+import { assert, expect } from 'chai';
+import { sexprs, toValue } from '@speclynx/apidom-core';
 
 import { refractJSONSchema } from '../../../../src/index.ts';
 
@@ -92,6 +92,15 @@ describe('refractor', function () {
         });
 
         expect(sexprs(jsonSchemaElement)).toMatchSnapshot();
+      });
+
+      context('given $ref field', function () {
+        specify('should contain referenced-element meta', function () {
+          const jsonSchemaElement = refractJSONSchema({ $ref: '#/components/inputs/Input1' });
+          const referencedElementMeta = jsonSchemaElement.meta.get('referenced-element');
+
+          assert.strictEqual(toValue(referencedElementMeta), 'JSONSchema');
+        });
       });
 
       context('given embedded JSONSchemaElements', function () {


### PR DESCRIPTION
## Summary

`apidom-ns-arazzo-1` registers its JSON-Schema-shaped element as `JSONSchema`, but the `referenced-element` meta on `$ref`-bearing schemas is tagged `schema` — a name nothing in the namespace resolves to.

The tag comes from `JSONSchemaVisitor.ObjectElement()` in `apidom-ns-json-schema-2019-09`, inherited through `arazzo-1` → `json-schema-2020-12` → `json-schema-2019-09`, where it is a hardcoded literal. Arazzo's visitor was a bare subclass that only swapped the element class, so it picked the constant up unchanged.

Everywhere else in this repo `referenced-element` mirrors the target class's own `element` name (`channelItem` → `channelItem`, `requestBody` → `requestBody`, …), and consumers rely on that — the tag is compared against `referencedElement.element` and fed into `refract(el, { element: tag })` (`packages/apidom-reference/src/bundle/strategies/openapi-3-1/visitor.ts:484,497`). With the tag reading `schema`, local `$ref`s into `workflow.inputs` / `components.inputs` were unresolvable whether or not the target existed.

This overrides `ObjectElement()` in Arazzo's own visitor to mirror the element's name:

```ts
ObjectElement(path: Path<ObjectElement>) {
  super.ObjectElement(path);

  // the inherited visitor tags `schema`, which no Arazzo element is named;
  // consumers match this value against an element name, so mirror our own
  if (isStringElement(this.element.$ref)) {
    this.element.meta.set('referenced-element', this.element.element);
  }
}
```

## Scope

Deliberately contained to `apidom-ns-arazzo-1`. The JSON Schema namespaces are left untouched, so no published metadata changes in `apidom-ns-json-schema-2019-09` or `-2020-12`.

Worth recording for whoever picks this up next: the same hardcoded literal means `apidom-ns-json-schema-2019-09` and `-2020-12` tag their own elements (`JSONSchema201909`, `JSONSchema202012`) as `schema` too, so anyone consuming those namespaces directly hits the same mismatch. Fixing it at the shared base would cover all three at once, at the cost of changing published metadata in two widely-consumed packages. That trade was considered and deferred; this PR takes the contained option.

## Relation to #427

Refs #427.

That issue reported Arazzo local `$ref`s as unresolvable and diagnosed it as *missing* reference tagging. That diagnosis was wrong — the tagging is present, inherited from the 2019-09 visitor — and the issue was closed as "no change needed in this repository," with the fault placed downstream.

The downstream half holds: the consumer-side matching was fixed structurally in speclynx/apidom-internal#196, and that fix is worth keeping regardless. But the tag's *value* was never examined, and it is wrong — which is what this PR corrects.

## Tests

Added a regression test asserting the tag equals `JSONSchema`, following the existing pattern in `apidom-ns-openapi-3-0/test/refractor/elements/Schema/index.ts:83-88`. Confirmed it fails without the override (`expected 'schema' to equal 'JSONSchema'`) rather than passing vacuously.

- `apidom-ns-arazzo-1` — 147 passing, no snapshot churn
- `npm run lint` at baseline (4 warnings, 0 errors), `typescript:check-types` clean

No snapshots move: element-level snapshots use `sexprs`, which serializes element names and drops `meta`.
