### PR TITLE
fix: make YAML style round-trips byte-perfect (comments, raw numbers)

### DIFF
--- a/packages/apidom-core/README.md
+++ b/packages/apidom-core/README.md
@@ -628,9 +628,11 @@ toYAML(objElement);
 `toYAML` accepts an optional second argument with serialization options. When `preserveStyle` is `true`,
 the serializer uses style information from `element.style.yaml` (captured during parsing with `style: true`)
 to preserve original formatting such as quoting styles, flow/block collections, comments, and indentation.
-Number format categories (exponential, hex, octal, fractional digits) are also preserved, though the
-underlying yaml library may normalize the exact representation (e.g., `1.0e10` becomes `1e+10`,
-`0x1A` becomes `0x1a`).
+Raw number representations (e.g. `1.0e10`, `0.50`) are preserved verbatim as long as they still
+represent the element's current value; when the value was changed without updating the captured
+raw content, the serializer falls back to preserving only the format category (exponential, hex,
+octal, fractional digits), letting the underlying yaml library normalize the exact representation
+(e.g., `1.0e10` becomes `1e+10`).
 
 ```js
 import { toYAML } from '@speclynx/apidom-core';

--- a/packages/apidom-core/src/transformers/serializers/yaml-1-2.ts
+++ b/packages/apidom-core/src/transformers/serializers/yaml-1-2.ts
@@ -48,10 +48,11 @@ const scalarStyleMap: Record<string, Scalar.Type> = {
   Folded: Scalar.BLOCK_FOLDED,
 };
 
-// the YAML library prefixes comments with '#' only (no space), so we add ' ' to get '# comment'
+// the YAML library emits comments as `#${text}` verbatim; style values carry the original
+// text after '#' (including any leading whitespace), so pass them through unchanged
 const applyComments = (node: YAMLNode, style: YAMLElementStyle): void => {
-  if (style.comment) node.comment = ` ${style.comment}`;
-  if (style.commentBefore) node.commentBefore = ` ${style.commentBefore}`;
+  if (style.comment) node.comment = style.comment;
+  if (style.commentBefore) node.commentBefore = style.commentBefore;
 };
 
 /**
@@ -96,10 +97,10 @@ const toYAMLNode = (element: unknown, visited: WeakSet<object>): unknown => {
       const pair = new Pair(keyNode, valueNode);
 
       if (memberStyle.commentBefore && isNode(keyNode)) {
-        keyNode.commentBefore = ` ${memberStyle.commentBefore}`;
+        keyNode.commentBefore = memberStyle.commentBefore;
       }
       if (memberStyle.comment && isNode(valueNode)) {
-        valueNode.comment = ` ${memberStyle.comment}`;
+        valueNode.comment = memberStyle.comment;
       }
 
       map.items.push(pair);

--- a/packages/apidom-core/src/transformers/serializers/yaml-1-2.ts
+++ b/packages/apidom-core/src/transformers/serializers/yaml-1-2.ts
@@ -10,6 +10,7 @@ import {
   type CreateNodeOptions,
   type DocumentOptions,
   type SchemaOptions,
+  type ScalarTag,
   type ToStringOptions,
 } from 'yaml';
 import {
@@ -71,6 +72,25 @@ export interface YAMLSerializerOptions
   /** Padding inside flow collections (e.g. `{ a: 1 }` vs `{a: 1}`) */
   flowCollectionPadding?: boolean;
 }
+
+// the YAML library re-derives number text from the JS value (normalizing e.g.
+// 1e3 -> 1e+3, 0x1A -> 0x1a) and has no per-node verbatim hook, so numbers with
+// faithful rawContent are boxed and emitted through a custom tag whose stringify
+// returns the original text; `default: true` keeps the tag implicit in the output
+class RawNumber {
+  constructor(
+    public value: number,
+    public raw: string,
+  ) {}
+}
+
+const rawNumberTag: ScalarTag = {
+  tag: 'tag:yaml.org,2002:float',
+  default: true,
+  identify: (value: unknown): boolean => value instanceof RawNumber,
+  resolve: (str: string): number => Number(str),
+  stringify: (item): string => (item.value as RawNumber).raw,
+};
 
 /**
  * Converts an ApiDOM element tree to YAML library AST nodes,
@@ -137,21 +157,27 @@ const toYAMLNode = (element: unknown, visited: WeakSet<object>): unknown => {
     scalar.type = scalarType;
   }
 
-  // use rawContent to infer YAML library format hints for plain scalars that resolved to numbers;
-  // only applies to Plain style — quoted scalars are always strings in YAML.
-  // note: the YAML library may normalize the representation (e.g. 1.0e10 -> 1e+10, 0x1A -> 0x1a)
-  // while preserving the format category (exponential, hex, octal, fractional digits)
+  // emit raw number content verbatim for plain scalars whose rawContent still
+  // faithfully represents the current value; only applies to Plain style —
+  // quoted scalars are always strings in YAML
   if (style.rawContent && style.scalarStyle === 'Plain' && typeof scalar.value === 'number') {
-    if (/[eE]/.test(style.rawContent)) {
-      scalar.format = 'EXP';
-    } else if (/^0x/i.test(style.rawContent)) {
-      scalar.format = 'HEX';
-    } else if (/^0o/i.test(style.rawContent)) {
-      scalar.format = 'OCT';
-    }
-    const dotMatch = style.rawContent.match(/\.(\d+)/);
-    if (dotMatch) {
-      scalar.minFractionDigits = dotMatch[1].length;
+    if (Number(style.rawContent) === scalar.value) {
+      scalar.value = new RawNumber(scalar.value, style.rawContent);
+    } else {
+      // fallback: infer YAML library format hints; the library may normalize the
+      // representation (e.g. 1.0e10 -> 1e+10, 0x1A -> 0x1a) while preserving the
+      // format category (exponential, hex, octal, fractional digits)
+      if (/[eE]/.test(style.rawContent)) {
+        scalar.format = 'EXP';
+      } else if (/^0x/i.test(style.rawContent)) {
+        scalar.format = 'HEX';
+      } else if (/^0o/i.test(style.rawContent)) {
+        scalar.format = 'OCT';
+      }
+      const dotMatch = style.rawContent.match(/\.(\d+)/);
+      if (dotMatch) {
+        scalar.minFractionDigits = dotMatch[1].length;
+      }
     }
   }
 
@@ -184,7 +210,7 @@ const serializer = (
     }
 
     const rootNode = toYAMLNode(element, new WeakSet());
-    const doc = new Document(undefined, allOptions);
+    const doc = new Document(undefined, { ...allOptions, customTags: [rawNumberTag] });
     doc.contents = rootNode as YAMLNode;
 
     if (directive) {

--- a/packages/apidom-core/test/transformers/serializers/yaml1-2-preserve-style.ts
+++ b/packages/apidom-core/test/transformers/serializers/yaml1-2-preserve-style.ts
@@ -72,9 +72,7 @@ describe('serializers', function () {
     });
 
     context('given NumberElement with exponential rawContent', function () {
-      // the yaml library normalizes exponential notation (e.g. 1.0e10 -> 1e+10);
-      // we preserve the exponential form but not the exact original representation
-      specify('should preserve exponential format', function () {
+      specify('should preserve original representation verbatim', function () {
         const element = new ObjectElement({});
         const numElement = new NumberElement(10000000000);
         numElement.style = { yaml: { scalarStyle: 'Plain', indent: 2, rawContent: '1.0e10' } };
@@ -83,12 +81,12 @@ describe('serializers', function () {
 
         const result = serialize(element, { preserveStyle: true });
 
-        assert.strictEqual(result, 'key: 1e+10\n');
+        assert.strictEqual(result, 'key: 1.0e10\n');
       });
     });
 
     context('given NumberElement with hex rawContent', function () {
-      specify('should preserve hex format', function () {
+      specify('should preserve original representation verbatim', function () {
         const element = new ObjectElement({});
         const numElement = new NumberElement(26);
         numElement.style = { yaml: { scalarStyle: 'Plain', indent: 2, rawContent: '0x1A' } };
@@ -97,7 +95,36 @@ describe('serializers', function () {
 
         const result = serialize(element, { preserveStyle: true });
 
-        assert.strictEqual(result, 'key: 0x1a\n');
+        assert.strictEqual(result, 'key: 0x1A\n');
+      });
+    });
+
+    context('given NumberElement with stale rawContent', function () {
+      // a plugin changed the value but left the original rawContent behind;
+      // the stale text must not be emitted — fall back to format hints
+      specify('should fall back to format-preserving serialization', function () {
+        const element = new ObjectElement({});
+        const numElement = new NumberElement(2000);
+        numElement.style = { yaml: { scalarStyle: 'Plain', indent: 2, rawContent: '1e3' } };
+        element.set('key', numElement);
+        element.style = { yaml: { styleGroup: 'Block', indent: 2 } };
+
+        const result = serialize(element, { preserveStyle: true });
+
+        assert.strictEqual(result, 'key: 2e+3\n');
+      });
+    });
+
+    context('given NumberElement with rawContent inside a flow sequence', function () {
+      specify('should preserve original representation verbatim', function () {
+        const numElement = new NumberElement(1000);
+        numElement.style = { yaml: { scalarStyle: 'Plain', indent: 2, rawContent: '1e3' } };
+        const element = new ArrayElement([numElement, 2]);
+        element.style = { yaml: { styleGroup: 'Flow', indent: 2 } };
+
+        const result = serialize(element, { preserveStyle: true });
+
+        assert.strictEqual(result, '[ 1e3, 2 ]\n');
       });
     });
 

--- a/packages/apidom-core/test/transformers/serializers/yaml1-2-preserve-style.ts
+++ b/packages/apidom-core/test/transformers/serializers/yaml1-2-preserve-style.ts
@@ -210,6 +210,18 @@ describe('serializers', function () {
       });
     });
 
+    context('given element with empty comment', function () {
+      specify('should emit a bare "#" for the single-space encoding', function () {
+        const element = new ObjectElement({ a: 1 });
+        element.style = { yaml: { styleGroup: 'Block', indent: 2, comment: ' ' } };
+
+        const result = serialize(element, { preserveStyle: true });
+
+        assert.include(result, '#');
+        assert.notInclude(result, '# ');
+      });
+    });
+
     context('given no style on element', function () {
       specify('should fall back to defaults', function () {
         const element = new ObjectElement({ a: 'b' });

--- a/packages/apidom-core/test/transformers/serializers/yaml1-2-preserve-style.ts
+++ b/packages/apidom-core/test/transformers/serializers/yaml1-2-preserve-style.ts
@@ -162,7 +162,7 @@ describe('serializers', function () {
     context('given element with comment', function () {
       specify('should preserve inline comment', function () {
         const element = new ObjectElement({ a: 1 });
-        element.style = { yaml: { styleGroup: 'Block', indent: 2, comment: 'my comment' } };
+        element.style = { yaml: { styleGroup: 'Block', indent: 2, comment: ' my comment' } };
 
         const result = serialize(element, { preserveStyle: true });
 
@@ -174,7 +174,7 @@ describe('serializers', function () {
       specify('should preserve comment before node', function () {
         const element = new ObjectElement({ a: 1 });
         element.style = {
-          yaml: { styleGroup: 'Block', indent: 2, commentBefore: 'before comment' },
+          yaml: { styleGroup: 'Block', indent: 2, commentBefore: ' before comment' },
         };
 
         const result = serialize(element, { preserveStyle: true });

--- a/packages/apidom-parser-adapter-yaml-1-2/src/tree-sitter/syntactic-analysis/CstTransformer.ts
+++ b/packages/apidom-parser-adapter-yaml-1-2/src/tree-sitter/syntactic-analysis/CstTransformer.ts
@@ -156,11 +156,12 @@ const processChildren = (
   return results;
 };
 
-// strip leading '# ' (or bare '#') from comment text, keeping only the content
+// strip leading '#' from each line of comment text; the text after '#' is kept
+// verbatim (including leading whitespace) so serializers can round-trip it exactly
 const stripCommentHash = (text: string): string =>
   text
     .split('\n')
-    .map((line) => line.replace(/^#\s?/, ''))
+    .map((line) => line.replace(/^#/, ''))
     .join('\n');
 
 // find the first YamlNode in a TransformResult (which may be an array from block_node)
@@ -174,11 +175,16 @@ const findYamlNode = (result: TransformResult): YamlNode | null => {
   return null;
 };
 
+interface PairComment {
+  text: string;
+  startLine?: number;
+}
+
 interface KeyValuePairResult {
   key: TransformResult | null;
   value: TransformResult | null;
   errors: TransformResult[];
-  commentsBetweenKeyValue: string[];
+  commentsBetweenKeyValue: PairComment[];
   commentsAfterValue: string[];
 }
 
@@ -191,7 +197,7 @@ const processKeyValuePairChildren = (
   let key: TransformResult | null = null;
   let value: TransformResult | null = null;
   const errors: TransformResult[] = [];
-  const commentsBetweenKeyValue: string[] = [];
+  const commentsBetweenKeyValue: PairComment[] = [];
   const commentsAfterValue: string[] = [];
   let siblings: SiblingContext = {};
   let seenKey = false;
@@ -218,7 +224,7 @@ const processKeyValuePairChildren = (
         if (seenValue) {
           commentsAfterValue.push(commentText);
         } else if (seenKey) {
-          commentsBetweenKeyValue.push(commentText);
+          commentsBetweenKeyValue.push({ text: commentText, startLine: info.startPosition.row });
         }
         continue;
       }
@@ -501,11 +507,20 @@ const createTransformers = (transformerMap: TransformerMap): TransformerMap => (
       children.push(value);
     }
 
-    // attach comments found between key and value to the value node
+    // attach comments found between key and value: comments on the key's own line
+    // belong after the key (`key: # comment`), the rest before the value node
     if (commentsBetweenKeyValue.length > 0) {
+      const keyNode = findYamlNode(key);
       const valueNode = findYamlNode(value);
-      if (valueNode) {
-        valueNode.commentBefore = commentsBetweenKeyValue.join('\n');
+      const onKeyLine = commentsBetweenKeyValue.filter(
+        (comment) => keyNode !== null && comment.startLine === keyNode.endLine,
+      );
+      const onOwnLine = commentsBetweenKeyValue.filter((comment) => !onKeyLine.includes(comment));
+      if (onKeyLine.length > 0 && keyNode) {
+        keyNode.comment = onKeyLine.map((comment) => comment.text).join('\n');
+      }
+      if (onOwnLine.length > 0 && valueNode) {
+        valueNode.commentBefore = onOwnLine.map((comment) => comment.text).join('\n');
       }
     }
     // attach comments found after value to the value node
@@ -594,11 +609,20 @@ const createTransformers = (transformerMap: TransformerMap): TransformerMap => (
       children.push(value);
     }
 
-    // attach comments found between key and value to the value node
+    // attach comments found between key and value: comments on the key's own line
+    // belong after the key (`key: # comment`), the rest before the value node
     if (commentsBetweenKeyValue.length > 0) {
+      const keyNode = findYamlNode(key);
       const valueNode = findYamlNode(value);
-      if (valueNode) {
-        valueNode.commentBefore = commentsBetweenKeyValue.join('\n');
+      const onKeyLine = commentsBetweenKeyValue.filter(
+        (comment) => keyNode !== null && comment.startLine === keyNode.endLine,
+      );
+      const onOwnLine = commentsBetweenKeyValue.filter((comment) => !onKeyLine.includes(comment));
+      if (onKeyLine.length > 0 && keyNode) {
+        keyNode.comment = onKeyLine.map((comment) => comment.text).join('\n');
+      }
+      if (onOwnLine.length > 0 && valueNode) {
+        valueNode.commentBefore = onOwnLine.map((comment) => comment.text).join('\n');
       }
     }
     // attach comments found after value to the value node

--- a/packages/apidom-parser-adapter-yaml-1-2/src/tree-sitter/syntactic-analysis/CstTransformer.ts
+++ b/packages/apidom-parser-adapter-yaml-1-2/src/tree-sitter/syntactic-analysis/CstTransformer.ts
@@ -250,6 +250,37 @@ const processKeyValuePairChildren = (
   return { key, value, errors, commentsBetweenKeyValue, commentsAfterValue };
 };
 
+// attach comments collected inside a pair: comments on the key's own line belong
+// after the key (`key: # comment`), the rest before the value node; comments
+// found after the value become the value's trailing comment
+const attachPairComments = ({
+  key,
+  value,
+  commentsBetweenKeyValue,
+  commentsAfterValue,
+}: KeyValuePairResult): void => {
+  if (commentsBetweenKeyValue.length > 0) {
+    const keyNode = findYamlNode(key);
+    const valueNode = findYamlNode(value);
+    const onKeyLine = commentsBetweenKeyValue.filter(
+      (comment) => keyNode !== null && comment.startLine === keyNode.endLine,
+    );
+    const onOwnLine = commentsBetweenKeyValue.filter((comment) => !onKeyLine.includes(comment));
+    if (onKeyLine.length > 0 && keyNode) {
+      keyNode.comment = onKeyLine.map((comment) => comment.text).join('\n');
+    }
+    if (onOwnLine.length > 0 && valueNode) {
+      valueNode.commentBefore = onOwnLine.map((comment) => comment.text).join('\n');
+    }
+  }
+  if (commentsAfterValue.length > 0) {
+    const valueNode = findYamlNode(value);
+    if (valueNode) {
+      valueNode.comment = commentsAfterValue.join('\n');
+    }
+  }
+};
+
 const transform = (
   cursor: TreeCursor,
   ctx: TransformContext,
@@ -464,8 +495,8 @@ const createTransformers = (transformerMap: TransformerMap): TransformerMap => (
   block_mapping_pair(cursor: TreeCursor, ctx: TransformContext): YamlKeyValuePair {
     const info = getCursorInfo(cursor);
 
-    const { key, value, errors, commentsBetweenKeyValue, commentsAfterValue } =
-      processKeyValuePairChildren(cursor, ctx, transformerMap);
+    const pairResult = processKeyValuePairChildren(cursor, ctx, transformerMap);
+    const { key, value, errors } = pairResult;
 
     const children: TransformResult[] = [];
 
@@ -507,29 +538,7 @@ const createTransformers = (transformerMap: TransformerMap): TransformerMap => (
       children.push(value);
     }
 
-    // attach comments found between key and value: comments on the key's own line
-    // belong after the key (`key: # comment`), the rest before the value node
-    if (commentsBetweenKeyValue.length > 0) {
-      const keyNode = findYamlNode(key);
-      const valueNode = findYamlNode(value);
-      const onKeyLine = commentsBetweenKeyValue.filter(
-        (comment) => keyNode !== null && comment.startLine === keyNode.endLine,
-      );
-      const onOwnLine = commentsBetweenKeyValue.filter((comment) => !onKeyLine.includes(comment));
-      if (onKeyLine.length > 0 && keyNode) {
-        keyNode.comment = onKeyLine.map((comment) => comment.text).join('\n');
-      }
-      if (onOwnLine.length > 0 && valueNode) {
-        valueNode.commentBefore = onOwnLine.map((comment) => comment.text).join('\n');
-      }
-    }
-    // attach comments found after value to the value node
-    if (commentsAfterValue.length > 0) {
-      const valueNode = findYamlNode(value);
-      if (valueNode) {
-        valueNode.comment = commentsAfterValue.join('\n');
-      }
-    }
+    attachPairComments(pairResult);
 
     children.push(...errors);
 
@@ -566,8 +575,8 @@ const createTransformers = (transformerMap: TransformerMap): TransformerMap => (
   flow_pair(cursor: TreeCursor, ctx: TransformContext): YamlKeyValuePair {
     const info = getCursorInfo(cursor);
 
-    const { key, value, errors, commentsBetweenKeyValue, commentsAfterValue } =
-      processKeyValuePairChildren(cursor, ctx, transformerMap);
+    const pairResult = processKeyValuePairChildren(cursor, ctx, transformerMap);
+    const { key, value, errors } = pairResult;
 
     const children: TransformResult[] = [];
 
@@ -609,29 +618,7 @@ const createTransformers = (transformerMap: TransformerMap): TransformerMap => (
       children.push(value);
     }
 
-    // attach comments found between key and value: comments on the key's own line
-    // belong after the key (`key: # comment`), the rest before the value node
-    if (commentsBetweenKeyValue.length > 0) {
-      const keyNode = findYamlNode(key);
-      const valueNode = findYamlNode(value);
-      const onKeyLine = commentsBetweenKeyValue.filter(
-        (comment) => keyNode !== null && comment.startLine === keyNode.endLine,
-      );
-      const onOwnLine = commentsBetweenKeyValue.filter((comment) => !onKeyLine.includes(comment));
-      if (onKeyLine.length > 0 && keyNode) {
-        keyNode.comment = onKeyLine.map((comment) => comment.text).join('\n');
-      }
-      if (onOwnLine.length > 0 && valueNode) {
-        valueNode.commentBefore = onOwnLine.map((comment) => comment.text).join('\n');
-      }
-    }
-    // attach comments found after value to the value node
-    if (commentsAfterValue.length > 0) {
-      const valueNode = findYamlNode(value);
-      if (valueNode) {
-        valueNode.comment = commentsAfterValue.join('\n');
-      }
-    }
+    attachPairComments(pairResult);
 
     children.push(...errors);
 

--- a/packages/apidom-parser-adapter-yaml-1-2/src/tree-sitter/syntactic-analysis/CstTransformer.ts
+++ b/packages/apidom-parser-adapter-yaml-1-2/src/tree-sitter/syntactic-analysis/CstTransformer.ts
@@ -157,11 +157,13 @@ const processChildren = (
 };
 
 // strip leading '#' from each line of comment text; the text after '#' is kept
-// verbatim (including leading whitespace) so serializers can round-trip it exactly
+// verbatim (including leading whitespace) so serializers can round-trip it exactly;
+// a bare '#' becomes a single space — the yaml library's encoding for an empty
+// comment, which its stringifier turns back into '#' (plain '' would be dropped)
 const stripCommentHash = (text: string): string =>
   text
     .split('\n')
-    .map((line) => line.replace(/^#/, ''))
+    .map((line) => (line === '#' ? ' ' : line.replace(/^#/, '')))
     .join('\n');
 
 // find the first YamlNode in a TransformResult (which may be an array from block_node)

--- a/packages/apidom-parser-adapter-yaml-1-2/src/tree-sitter/syntactic-analysis/YamlAstTransformer.ts
+++ b/packages/apidom-parser-adapter-yaml-1-2/src/tree-sitter/syntactic-analysis/YamlAstTransformer.ts
@@ -22,6 +22,7 @@ import type YamlKeyValuePair from './ast/nodes/YamlKeyValuePair.ts';
 import type YamlSequence from './ast/nodes/YamlSequence.ts';
 import type YamlScalar from './ast/nodes/YamlScalar.ts';
 import type YamlNode from './ast/nodes/YamlNode.ts';
+import { isComment, isDocument } from './ast/nodes/predicates.ts';
 import { YamlStyle, YamlStyleGroup } from './ast/nodes/YamlStyle.ts';
 
 // Transform context passed through transformation
@@ -180,6 +181,9 @@ const setYamlStyleProp = (element: Element, key: string, value: string): void =>
   element.style.yaml = yaml;
 };
 
+const getYamlStyleProp = (element: Element, key: string): unknown =>
+  (element.style?.yaml as Record<string, unknown> | undefined)?.[key];
+
 // apply collected comments to transformed ApiDOM elements
 const applyComments = (elements: Element[], comments: CommentAssociations): void => {
   comments.before.forEach((text, idx) => {
@@ -324,6 +328,17 @@ const transformChildren = (children: unknown[], ctx: TransformContext): Element[
   return results;
 };
 
+// stream comments that precede the first document, joined; null when there are none
+// (stream children are in source order, so everything before the document node qualifies)
+const collectPreDocumentComments = (node: YamlStream): string | null => {
+  const texts: string[] = [];
+  for (const child of node.children) {
+    if (isDocument(child)) break;
+    if (isComment(child)) texts.push(stripCommentHash(child.content));
+  }
+  return texts.length > 0 ? texts.join('\n') : null;
+};
+
 // Stream: Wraps transformed children in ParseResultElement
 const transformStream = (node: YamlStream, ctx: TransformContext): ParseResultElement => {
   // detect indent from the stream structure (only needed for style preservation)
@@ -350,21 +365,16 @@ const transformStream = (node: YamlStream, ctx: TransformContext): ParseResultEl
     // stream comments before the first document belong above the result element;
     // capture them as commentBefore so style round-trips can re-emit them
     if (ctx.style) {
-      const streamChildren = (node.children || []) as (TypedNode & { content?: string })[];
-      const firstDocument = streamChildren.find((child) => child?.type === 'document');
-      const preDocumentComments = streamChildren.filter(
-        (child) =>
-          child?.type === 'comment' &&
-          (firstDocument === undefined ||
-            (child.startOffset ?? 0) < (firstDocument.startOffset ?? Infinity)),
-      );
-      if (preDocumentComments.length > 0) {
-        const text = preDocumentComments
-          .map((comment) => stripCommentHash(comment.content || ''))
-          .join('\n');
-        const existing = (resultElement.style?.yaml as Record<string, unknown> | undefined)
-          ?.commentBefore as string | undefined;
-        setYamlStyleProp(resultElement, 'commentBefore', existing ? `${text}\n${existing}` : text);
+      const preDocumentComments = collectPreDocumentComments(node);
+      if (preDocumentComments !== null) {
+        const existing = getYamlStyleProp(resultElement, 'commentBefore');
+        setYamlStyleProp(
+          resultElement,
+          'commentBefore',
+          typeof existing === 'string'
+            ? `${preDocumentComments}\n${existing}`
+            : preDocumentComments,
+        );
       }
     }
   }

--- a/packages/apidom-parser-adapter-yaml-1-2/src/tree-sitter/syntactic-analysis/YamlAstTransformer.ts
+++ b/packages/apidom-parser-adapter-yaml-1-2/src/tree-sitter/syntactic-analysis/YamlAstTransformer.ts
@@ -92,11 +92,14 @@ const detectIndent = (node: YamlStream): number => {
   return 2;
 };
 
-// strip leading '#' from each line of comment text; yaml library adds '#' during stringification
+// strip leading '#' from each line of comment text; yaml library adds '#' during
+// stringification; a bare '#' becomes a single space — the yaml library's encoding
+// for an empty comment, which its stringifier turns back into '#' (plain '' would
+// be dropped)
 const stripCommentHash = (text: string): string =>
   text
     .split('\n')
-    .map((line) => line.replace(/^#/, ''))
+    .map((line) => (line === '#' ? ' ' : line.replace(/^#/, '')))
     .join('\n');
 
 // collect comment texts from raw AST children, indexed by position relative to non-comment siblings

--- a/packages/apidom-parser-adapter-yaml-1-2/src/tree-sitter/syntactic-analysis/YamlAstTransformer.ts
+++ b/packages/apidom-parser-adapter-yaml-1-2/src/tree-sitter/syntactic-analysis/YamlAstTransformer.ts
@@ -346,6 +346,27 @@ const transformStream = (node: YamlStream, ctx: TransformContext): ParseResultEl
   if (elements.length > 0) {
     const resultElement = elements[0];
     resultElement.classes.push('result');
+
+    // stream comments before the first document belong above the result element;
+    // capture them as commentBefore so style round-trips can re-emit them
+    if (ctx.style) {
+      const streamChildren = (node.children || []) as (TypedNode & { content?: string })[];
+      const firstDocument = streamChildren.find((child) => child?.type === 'document');
+      const preDocumentComments = streamChildren.filter(
+        (child) =>
+          child?.type === 'comment' &&
+          (firstDocument === undefined ||
+            (child.startOffset ?? 0) < (firstDocument.startOffset ?? Infinity)),
+      );
+      if (preDocumentComments.length > 0) {
+        const text = preDocumentComments
+          .map((comment) => stripCommentHash(comment.content || ''))
+          .join('\n');
+        const existing = (resultElement.style?.yaml as Record<string, unknown> | undefined)
+          ?.commentBefore as string | undefined;
+        setYamlStyleProp(resultElement, 'commentBefore', existing ? `${text}\n${existing}` : text);
+      }
+    }
   }
 
   // Add collected annotations

--- a/packages/apidom-parser-adapter-yaml-1-2/test/adapter/style-preservation.ts
+++ b/packages/apidom-parser-adapter-yaml-1-2/test/adapter/style-preservation.ts
@@ -1,0 +1,55 @@
+import { assert } from 'chai';
+
+import * as adapter from '../../src/adapter.ts';
+
+describe('adapter', function () {
+  context('given style preservation is enabled', function () {
+    context('given comment before the first document', function () {
+      specify('should capture it as commentBefore on the result element', async function () {
+        const source = '# top of document comment\na: 1\n';
+
+        const parseResult = await adapter.parse(source, { style: true });
+        const result = parseResult.result!;
+
+        assert.deepInclude(result.style?.yaml, { commentBefore: ' top of document comment' });
+      });
+    });
+
+    context('given multiple comments before the first document', function () {
+      specify('should capture them joined by newlines', async function () {
+        const source = '# first line\n# second line\na: 1\n';
+
+        const parseResult = await adapter.parse(source, { style: true });
+        const result = parseResult.result!;
+
+        assert.deepInclude(result.style?.yaml, { commentBefore: ' first line\n second line' });
+      });
+    });
+
+    context('given comment before a mapping entry', function () {
+      specify('should capture the text after "#" verbatim', async function () {
+        const source = 'a: 1\n# entry comment\nb: 2\n';
+
+        const parseResult = await adapter.parse(source, { style: true });
+        const result = parseResult.result!;
+        // @ts-ignore
+        const member = result.getMember('b');
+
+        assert.deepInclude(member.style?.yaml, { commentBefore: ' entry comment' });
+      });
+    });
+
+    context('given inline comment after a mapping entry', function () {
+      specify('should capture the text after "#" verbatim', async function () {
+        const source = 'a: 1 # inline comment\n';
+
+        const parseResult = await adapter.parse(source, { style: true });
+        const result = parseResult.result!;
+        // @ts-ignore
+        const member = result.getMember('a');
+
+        assert.deepInclude(member.style?.yaml, { comment: ' inline comment' });
+      });
+    });
+  });
+});

--- a/packages/apidom-parser-adapter-yaml-1-2/test/adapter/style-preservation.ts
+++ b/packages/apidom-parser-adapter-yaml-1-2/test/adapter/style-preservation.ts
@@ -51,5 +51,31 @@ describe('adapter', function () {
         assert.deepInclude(member.style?.yaml, { comment: ' inline comment' });
       });
     });
+
+    context('given comment on the key line before a nested block value', function () {
+      specify('should capture the text after "#" verbatim on the key', async function () {
+        const source = 'a: # key line comment\n    nested: 1\n';
+
+        const parseResult = await adapter.parse(source, { style: true });
+        const result = parseResult.result!;
+        // @ts-ignore
+        const member = result.getMember('a');
+
+        assert.deepInclude(member.key.style?.yaml, { comment: ' key line comment' });
+      });
+    });
+
+    context('given comment on its own line before a nested block value', function () {
+      specify('should capture the text after "#" verbatim on the value', async function () {
+        const source = 'a:\n    # own line comment\n    nested: 1\n';
+
+        const parseResult = await adapter.parse(source, { style: true });
+        const result = parseResult.result!;
+        // @ts-ignore
+        const member = result.getMember('a');
+
+        assert.deepInclude(member.value.style?.yaml, { commentBefore: ' own line comment' });
+      });
+    });
   });
 });

--- a/packages/apidom-parser-adapter-yaml-1-2/test/adapter/style-preservation.ts
+++ b/packages/apidom-parser-adapter-yaml-1-2/test/adapter/style-preservation.ts
@@ -65,6 +65,22 @@ describe('adapter', function () {
       });
     });
 
+    context('given bare "#" comment after a mapping entry', function () {
+      specify(
+        'should capture it as a single space (yaml empty-comment encoding)',
+        async function () {
+          const source = 'a: 1 #\n';
+
+          const parseResult = await adapter.parse(source, { style: true });
+          const result = parseResult.result!;
+          // @ts-ignore
+          const member = result.getMember('a');
+
+          assert.deepInclude(member.style?.yaml, { comment: ' ' });
+        },
+      );
+    });
+
     context('given comment on its own line before a nested block value', function () {
       specify('should capture the text after "#" verbatim on the value', async function () {
         const source = 'a:\n    # own line comment\n    nested: 1\n';


### PR DESCRIPTION
Fixes the remaining fidelity gaps in YAML style-preserving round-trips (`parse(source, { style: true })` → `toYAML(element, { preserveStyle: true })`): comments and raw number representations.

## Comments

1. **Comments came back with a doubled space.** The parser captures the text after `#` verbatim (including its leading space), while the serializer prepended another space — so `# comment` serialized as `#  comment`. The serializer now passes the captured text through unchanged, making comment spacing byte-perfect regardless of the original style (`#comment`, `# comment`, `#   comment`).

2. **A comment at the top of the document was dropped entirely.** Comments preceding the first document only became `CommentElement` siblings in the `ParseResultElement`, so `element.style` never saw them and serializing the result element lost them. With style preservation enabled, the adapter now also captures pre-document stream comments as `commentBefore` style on the result element (joined by newlines when there are several).

3. **In-pair comments lost their leading space and their position** (per Copilot's review). `CstTransformer`'s `stripCommentHash` stripped `#` plus one space, breaking the verbatim contract for comments tree-sitter places inside a key/value pair. It now strips only `#`. Additionally, a comment on the key's own line (`key: # comment` before a nested block value) is attached to the key so serialization re-emits it after the key instead of moving it to its own line above the value.

## Raw number representations

The yaml library re-derives number text from the JS value, normalizing raw representations (`1e3` → `1e+3`, `10e2` → `1e+3`, `100.000` → `100`), and there is no per-node verbatim hook (number-looking plain strings get quoted, explicitly tagged scalars render as `!!float`). Numbers whose captured `rawContent` still represents the current value are now boxed in a private `RawNumber` class and emitted through a custom schema tag whose `stringify` returns the original text verbatim — `default: true` keeps the tag implicit, so the output is just `maximum: 1e3`. Comments, flow context, and use as mapping keys are unaffected. When `rawContent` is stale (a plugin changed the value without updating it), the scalar falls back to the previous format-category preservation.

## Verification

With these fixes, this document round-trips **byte-for-byte** through the refracted OpenAPI 3.1 path (`@speclynx/apidom-parser-adapter-openapi-yaml-3-1` → mutate → `toYAML`), with an added property as the only change:

```yaml
# Payments API — internal draft
openapi: 3.1.2
info:
    title: 'Payments API'
    # semantic versioning
    version: 1.0.0 # semver
    description: |-
        Create and track payments.
paths:
    /payments/{paymentId}:
        get:
            summary: Get a payment
            operationId: getPayment
            responses:
                "200":
                    description: OK
```

Raw numbers (`1e3`, `10E-2`, `0.50`, `100.000`) also verified byte-perfect end-to-end.

## Tests

- `apidom-core`: 169 passing — comment serializer tests updated to the verbatim contract; new tests for verbatim number representation, stale-`rawContent` fallback
- `apidom-parser-adapter-yaml-1-2`: 124 passing — new `test/adapter/style-preservation.ts` covering pre-document comments (single and multiple), `commentBefore` on mapping entries, inline comments, in-pair comments (key-line and own-line placements), and bare `#` comments

