### PR TITLE
fix(ns): transfer style in refractor visitors using the concat pattern

### DIFF
--- a/packages/apidom-ns-openapi-2/src/refractor/plugins/normalize-parameters.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/plugins/normalize-parameters.ts
@@ -87,7 +87,7 @@ const inheritParametersToOperation = (
   // its meta, attributes, source map and style
   if (isArrayElement(originalParameters)) {
     if (!originalParameters.isMetaEmpty) {
-      mergedElement.meta = originalParameters.meta.cloneDeep();
+      mergedElement.meta = cloneDeep(originalParameters.meta);
     }
     if (!originalParameters.isAttributesEmpty) {
       mergedElement.attributes = cloneDeep(originalParameters.attributes);

--- a/packages/apidom-ns-openapi-2/src/refractor/plugins/normalize-parameters.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/plugins/normalize-parameters.ts
@@ -1,6 +1,13 @@
 import { uniqWith } from 'ramda';
 import { toValue } from '@speclynx/apidom-core';
-import { StringElement, isStringElement, isArrayElement } from '@speclynx/apidom-datamodel';
+import {
+  StringElement,
+  SourceMapElement,
+  StyleElement,
+  cloneDeep,
+  isStringElement,
+  isArrayElement,
+} from '@speclynx/apidom-datamodel';
 import { Path } from '@speclynx/apidom-traverse';
 
 import ParameterElement from '../../elements/Parameter.ts';
@@ -73,7 +80,23 @@ const inheritParametersToOperation = (
   // prefers the first item if two items compare equal based on the predicate
   const mergedParameters = uniqWith(parameterEquals, [...operationParams, ...pathItemParams]);
 
-  operationElement.parameters = new OperationParametersElement(mergedParameters);
+  const originalParameters = operationElement.parameters;
+  const mergedElement = new OperationParametersElement(mergedParameters);
+
+  // the merged container may replace an existing source container — carry over
+  // its meta, attributes, source map and style
+  if (isArrayElement(originalParameters)) {
+    if (!originalParameters.isMetaEmpty) {
+      mergedElement.meta = originalParameters.meta.cloneDeep();
+    }
+    if (!originalParameters.isAttributesEmpty) {
+      mergedElement.attributes = cloneDeep(originalParameters.attributes);
+    }
+    SourceMapElement.transfer(originalParameters, mergedElement);
+    StyleElement.transfer(originalParameters, mergedElement);
+  }
+
+  operationElement.parameters = mergedElement;
 };
 
 /**

--- a/packages/apidom-ns-openapi-2/src/refractor/visitors/open-api-2/ConsumesVisitor.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/visitors/open-api-2/ConsumesVisitor.ts
@@ -21,6 +21,7 @@ class ConsumesVisitor extends FallbackVisitor {
     const arrayElement = path.node;
 
     this.element = this.element.concat(cloneDeep(arrayElement));
+    this.copyMetaAndAttributes(arrayElement, this.element);
 
     path.stop();
   }

--- a/packages/apidom-ns-openapi-2/src/refractor/visitors/open-api-2/ProducesVisitor.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/visitors/open-api-2/ProducesVisitor.ts
@@ -21,6 +21,7 @@ class ProducesVisitor extends FallbackVisitor {
     const arrayElement = path.node;
 
     this.element = this.element.concat(cloneDeep(arrayElement));
+    this.copyMetaAndAttributes(arrayElement, this.element);
 
     path.stop();
   }

--- a/packages/apidom-ns-openapi-2/src/refractor/visitors/open-api-2/SchemesVisitor.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/visitors/open-api-2/SchemesVisitor.ts
@@ -21,6 +21,7 @@ class SchemesVisitor extends FallbackVisitor {
     const arrayElement = path.node;
 
     this.element = this.element.concat(cloneDeep(arrayElement));
+    this.copyMetaAndAttributes(arrayElement, this.element);
 
     path.stop();
   }

--- a/packages/apidom-ns-openapi-2/src/refractor/visitors/open-api-2/operation/ConsumesVisitor.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/visitors/open-api-2/operation/ConsumesVisitor.ts
@@ -21,6 +21,7 @@ class ConsumesVisitor extends FallbackVisitor {
     const arrayElement = path.node;
 
     this.element = this.element.concat(cloneDeep(arrayElement));
+    this.copyMetaAndAttributes(arrayElement, this.element);
 
     path.stop();
   }

--- a/packages/apidom-ns-openapi-2/src/refractor/visitors/open-api-2/operation/ProducesVisitor.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/visitors/open-api-2/operation/ProducesVisitor.ts
@@ -21,6 +21,7 @@ class ProducesVisitor extends FallbackVisitor {
     const arrayElement = path.node;
 
     this.element = this.element.concat(cloneDeep(arrayElement));
+    this.copyMetaAndAttributes(arrayElement, this.element);
 
     path.stop();
   }

--- a/packages/apidom-ns-openapi-2/src/refractor/visitors/open-api-2/operation/SchemesVisitor.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/visitors/open-api-2/operation/SchemesVisitor.ts
@@ -21,6 +21,7 @@ class SchemesVisitor extends FallbackVisitor {
     const arrayElement = path.node;
 
     this.element = this.element.concat(cloneDeep(arrayElement));
+    this.copyMetaAndAttributes(arrayElement, this.element);
 
     path.stop();
   }

--- a/packages/apidom-ns-openapi-2/src/refractor/visitors/open-api-2/operation/TagsVisitor.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/visitors/open-api-2/operation/TagsVisitor.ts
@@ -21,6 +21,7 @@ class TagsVisitor extends FallbackVisitor {
     const arrayElement = path.node;
 
     this.element = this.element.concat(cloneDeep(arrayElement));
+    this.copyMetaAndAttributes(arrayElement, this.element);
 
     path.stop();
   }

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Operation/index.ts
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Operation/index.ts
@@ -1,5 +1,5 @@
 import { assert, expect } from 'chai';
-import { includesClasses } from '@speclynx/apidom-datamodel';
+import { ArrayElement, ObjectElement, includesClasses } from '@speclynx/apidom-datamodel';
 import { sexprs } from '@speclynx/apidom-core';
 
 import { refractOperation, OperationElement } from '../../../../src/index.ts';
@@ -42,6 +42,25 @@ describe('refractor', function () {
             'specification-extension',
           ]),
         );
+      });
+
+      context('given array fields carrying style information', function () {
+        specify('should transfer style to the refracted elements', function () {
+          const style = { yaml: { styleGroup: 'Flow' } };
+          const fields = ['tags', 'consumes', 'produces', 'schemes'];
+          const operation = new ObjectElement({ summary: 'operation-summary' });
+          for (const field of fields) {
+            const array = new ArrayElement(['value1', 'value2']);
+            array.style = { ...style };
+            operation.set(field, array);
+          }
+
+          const operationElement = refractOperation(operation) as OperationElement;
+
+          for (const field of fields) {
+            assert.deepEqual((operationElement.get(field) as ArrayElement).style, style, field);
+          }
+        });
       });
     });
   });

--- a/packages/apidom-ns-openapi-2/test/refractor/elements/Swagger/index.ts
+++ b/packages/apidom-ns-openapi-2/test/refractor/elements/Swagger/index.ts
@@ -1,5 +1,5 @@
 import { assert, expect } from 'chai';
-import { includesClasses } from '@speclynx/apidom-datamodel';
+import { ArrayElement, ObjectElement, includesClasses } from '@speclynx/apidom-datamodel';
 import { sexprs } from '@speclynx/apidom-core';
 
 import { refractSwagger, SwaggerElement } from '../../../../src/index.ts';
@@ -53,6 +53,25 @@ describe('refractor', function () {
             'specification-extension',
           ]),
         );
+      });
+
+      context('given array fields carrying style information', function () {
+        specify('should transfer style to the refracted elements', function () {
+          const style = { yaml: { styleGroup: 'Flow' } };
+          const fields = ['schemes', 'consumes', 'produces'];
+          const swagger = new ObjectElement({ swagger: '2.0' });
+          for (const field of fields) {
+            const array = new ArrayElement(['value1', 'value2']);
+            array.style = { ...style };
+            swagger.set(field, array);
+          }
+
+          const swaggerElement = refractSwagger(swagger) as SwaggerElement;
+
+          for (const field of fields) {
+            assert.deepEqual((swaggerElement.get(field) as ArrayElement).style, style, field);
+          }
+        });
       });
     });
   });

--- a/packages/apidom-ns-openapi-2/test/refractor/plugins/normalize-parameters/container-preservation.ts
+++ b/packages/apidom-ns-openapi-2/test/refractor/plugins/normalize-parameters/container-preservation.ts
@@ -1,0 +1,66 @@
+import { assert } from 'chai';
+import { ArrayElement, ObjectElement } from '@speclynx/apidom-datamodel';
+import { toValue } from '@speclynx/apidom-core';
+
+import {
+  refractSwagger,
+  refractorPluginNormalizeParameters,
+  SwaggerElement,
+  OperationElement,
+} from '../../../../src/index.ts';
+
+describe('refractor', function () {
+  context('plugins', function () {
+    context('normalize-parameters', function () {
+      context(
+        'given Operation parameters carrying meta, attributes, source map and style',
+        function () {
+          specify('should preserve them on the merged parameters container', function () {
+            const parameters = new ArrayElement([{ name: 'param2', in: 'query' }]);
+            parameters.style = { yaml: { styleGroup: 'Flow' } };
+            parameters.meta.set('custom-meta', 'meta-value');
+            parameters.attributes.set('custom-attribute', 'attribute-value');
+            parameters.startLine = 1;
+            parameters.startCharacter = 2;
+            parameters.startOffset = 3;
+            parameters.endLine = 4;
+            parameters.endCharacter = 5;
+            parameters.endOffset = 6;
+
+            const operation = new ObjectElement();
+            operation.set('parameters', parameters);
+            const pathItem = new ObjectElement({
+              parameters: [{ name: 'param1', in: 'query' }],
+            });
+            pathItem.set('get', operation);
+            const paths = new ObjectElement();
+            paths.set('/', pathItem);
+            const definition = new ObjectElement({ swagger: '2.0' });
+            definition.set('paths', paths);
+
+            const swaggerElement = refractSwagger(definition, {
+              plugins: [refractorPluginNormalizeParameters()],
+            }) as SwaggerElement;
+
+            const operationElement = swaggerElement.paths?.get('/').get('get') as OperationElement;
+            const mergedParameters = operationElement.parameters as ArrayElement;
+
+            assert.lengthOf(mergedParameters.content, 2);
+            assert.deepEqual(mergedParameters.style, { yaml: { styleGroup: 'Flow' } });
+            assert.strictEqual(mergedParameters.meta.get('custom-meta'), 'meta-value');
+            assert.strictEqual(
+              toValue(mergedParameters.attributes.get('custom-attribute')),
+              'attribute-value',
+            );
+            assert.strictEqual(mergedParameters.startLine, 1);
+            assert.strictEqual(mergedParameters.startCharacter, 2);
+            assert.strictEqual(mergedParameters.startOffset, 3);
+            assert.strictEqual(mergedParameters.endLine, 4);
+            assert.strictEqual(mergedParameters.endCharacter, 5);
+            assert.strictEqual(mergedParameters.endOffset, 6);
+          });
+        },
+      );
+    });
+  });
+});

--- a/packages/apidom-ns-openapi-2/test/refractor/plugins/normalize-parameters/container-preservation.ts
+++ b/packages/apidom-ns-openapi-2/test/refractor/plugins/normalize-parameters/container-preservation.ts
@@ -42,10 +42,11 @@ describe('refractor', function () {
               plugins: [refractorPluginNormalizeParameters()],
             }) as SwaggerElement;
 
-            const operationElement = swaggerElement.paths?.get('/').get('get') as OperationElement;
+            const pathItemElement = swaggerElement.paths?.get('/') as ObjectElement;
+            const operationElement = pathItemElement.get('get') as OperationElement;
             const mergedParameters = operationElement.parameters as ArrayElement;
 
-            assert.lengthOf(mergedParameters.content, 2);
+            assert.strictEqual(mergedParameters.length, 2);
             assert.deepEqual(mergedParameters.style, { yaml: { styleGroup: 'Flow' } });
             assert.strictEqual(mergedParameters.meta.get('custom-meta'), 'meta-value');
             assert.strictEqual(

--- a/packages/apidom-ns-openapi-3-0/src/refractor/plugins/normalize-parameters.ts
+++ b/packages/apidom-ns-openapi-3-0/src/refractor/plugins/normalize-parameters.ts
@@ -1,6 +1,13 @@
 import { uniqWith } from 'ramda';
 import { toValue } from '@speclynx/apidom-core';
-import { StringElement, isStringElement, isArrayElement } from '@speclynx/apidom-datamodel';
+import {
+  StringElement,
+  SourceMapElement,
+  StyleElement,
+  cloneDeep,
+  isStringElement,
+  isArrayElement,
+} from '@speclynx/apidom-datamodel';
 import { Path } from '@speclynx/apidom-traverse';
 
 import ParameterElement from '../../elements/Parameter.ts';
@@ -72,7 +79,23 @@ const inheritParametersToOperation = (
   // prefers the first item if two items compare equal based on the predicate
   const mergedParameters = uniqWith(parameterEquals, [...operationParams, ...pathItemParams]);
 
-  operationElement.parameters = new OperationParametersElement(mergedParameters);
+  const originalParameters = operationElement.parameters;
+  const mergedElement = new OperationParametersElement(mergedParameters);
+
+  // the merged container may replace an existing source container — carry over
+  // its meta, attributes, source map and style
+  if (isArrayElement(originalParameters)) {
+    if (!originalParameters.isMetaEmpty) {
+      mergedElement.meta = originalParameters.meta.cloneDeep();
+    }
+    if (!originalParameters.isAttributesEmpty) {
+      mergedElement.attributes = cloneDeep(originalParameters.attributes);
+    }
+    SourceMapElement.transfer(originalParameters, mergedElement);
+    StyleElement.transfer(originalParameters, mergedElement);
+  }
+
+  operationElement.parameters = mergedElement;
 };
 
 /**

--- a/packages/apidom-ns-openapi-3-0/src/refractor/plugins/normalize-parameters.ts
+++ b/packages/apidom-ns-openapi-3-0/src/refractor/plugins/normalize-parameters.ts
@@ -86,7 +86,7 @@ const inheritParametersToOperation = (
   // its meta, attributes, source map and style
   if (isArrayElement(originalParameters)) {
     if (!originalParameters.isMetaEmpty) {
-      mergedElement.meta = originalParameters.meta.cloneDeep();
+      mergedElement.meta = cloneDeep(originalParameters.meta);
     }
     if (!originalParameters.isAttributesEmpty) {
       mergedElement.attributes = cloneDeep(originalParameters.attributes);

--- a/packages/apidom-ns-openapi-3-0/src/refractor/visitors/open-api-3-0/operation/TagsVisitor.ts
+++ b/packages/apidom-ns-openapi-3-0/src/refractor/visitors/open-api-3-0/operation/TagsVisitor.ts
@@ -24,6 +24,7 @@ class TagsVisitor extends FallbackVisitor {
     const arrayElement = path.node;
 
     this.element = this.element.concat(cloneDeep(arrayElement));
+    this.copyMetaAndAttributes(arrayElement, this.element);
 
     path.stop();
   }

--- a/packages/apidom-ns-openapi-3-0/test/refractor/elements/Operation/index.ts
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/elements/Operation/index.ts
@@ -1,5 +1,6 @@
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { sexprs } from '@speclynx/apidom-core';
+import { ArrayElement, ObjectElement } from '@speclynx/apidom-datamodel';
 
 import { refractOperation } from '../../../../src/index.ts';
 
@@ -51,6 +52,19 @@ describe('refractor', function () {
           });
 
           expect(sexprs(operationElement)).toMatchSnapshot();
+        });
+      });
+
+      context('given tags field carrying style information', function () {
+        specify('should transfer style to the refracted element', function () {
+          const tags = new ArrayElement(['tag1', 'tag2']);
+          tags.style = { yaml: { styleGroup: 'Flow' } };
+          const operation = new ObjectElement({ summary: 'operation-summary' });
+          operation.set('tags', tags);
+
+          const operationElement = refractOperation(operation);
+
+          assert.deepEqual(operationElement.tags?.style, { yaml: { styleGroup: 'Flow' } });
         });
       });
     });

--- a/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-parameters/container-preservation.ts
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-parameters/container-preservation.ts
@@ -42,10 +42,11 @@ describe('refractor', function () {
               plugins: [refractorPluginNormalizeParameters()],
             }) as OpenApi3_0Element;
 
-            const operationElement = openApiElement.paths?.get('/').get('get') as OperationElement;
+            const pathItemElement = openApiElement.paths?.get('/') as ObjectElement;
+            const operationElement = pathItemElement.get('get') as OperationElement;
             const mergedParameters = operationElement.parameters as ArrayElement;
 
-            assert.lengthOf(mergedParameters.content, 2);
+            assert.strictEqual(mergedParameters.length, 2);
             assert.deepEqual(mergedParameters.style, { yaml: { styleGroup: 'Flow' } });
             assert.strictEqual(mergedParameters.meta.get('custom-meta'), 'meta-value');
             assert.strictEqual(

--- a/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-parameters/container-preservation.ts
+++ b/packages/apidom-ns-openapi-3-0/test/refractor/plugins/normalize-parameters/container-preservation.ts
@@ -1,0 +1,66 @@
+import { assert } from 'chai';
+import { ArrayElement, ObjectElement } from '@speclynx/apidom-datamodel';
+import { toValue } from '@speclynx/apidom-core';
+
+import {
+  refractOpenApi3_0,
+  refractorPluginNormalizeParameters,
+  OpenApi3_0Element,
+  OperationElement,
+} from '../../../../src/index.ts';
+
+describe('refractor', function () {
+  context('plugins', function () {
+    context('normalize-parameters', function () {
+      context(
+        'given Operation parameters carrying meta, attributes, source map and style',
+        function () {
+          specify('should preserve them on the merged parameters container', function () {
+            const parameters = new ArrayElement([{ name: 'param2', in: 'query' }]);
+            parameters.style = { yaml: { styleGroup: 'Flow' } };
+            parameters.meta.set('custom-meta', 'meta-value');
+            parameters.attributes.set('custom-attribute', 'attribute-value');
+            parameters.startLine = 1;
+            parameters.startCharacter = 2;
+            parameters.startOffset = 3;
+            parameters.endLine = 4;
+            parameters.endCharacter = 5;
+            parameters.endOffset = 6;
+
+            const operation = new ObjectElement();
+            operation.set('parameters', parameters);
+            const pathItem = new ObjectElement({
+              parameters: [{ name: 'param1', in: 'query' }],
+            });
+            pathItem.set('get', operation);
+            const paths = new ObjectElement();
+            paths.set('/', pathItem);
+            const definition = new ObjectElement({ openapi: '3.0.4' });
+            definition.set('paths', paths);
+
+            const openApiElement = refractOpenApi3_0(definition, {
+              plugins: [refractorPluginNormalizeParameters()],
+            }) as OpenApi3_0Element;
+
+            const operationElement = openApiElement.paths?.get('/').get('get') as OperationElement;
+            const mergedParameters = operationElement.parameters as ArrayElement;
+
+            assert.lengthOf(mergedParameters.content, 2);
+            assert.deepEqual(mergedParameters.style, { yaml: { styleGroup: 'Flow' } });
+            assert.strictEqual(mergedParameters.meta.get('custom-meta'), 'meta-value');
+            assert.strictEqual(
+              toValue(mergedParameters.attributes.get('custom-attribute')),
+              'attribute-value',
+            );
+            assert.strictEqual(mergedParameters.startLine, 1);
+            assert.strictEqual(mergedParameters.startCharacter, 2);
+            assert.strictEqual(mergedParameters.startOffset, 3);
+            assert.strictEqual(mergedParameters.endLine, 4);
+            assert.strictEqual(mergedParameters.endCharacter, 5);
+            assert.strictEqual(mergedParameters.endOffset, 6);
+          });
+        },
+      );
+    });
+  });
+});

--- a/packages/apidom-ns-openapi-3-1/src/refractor/plugins/normalize-parameters.ts
+++ b/packages/apidom-ns-openapi-3-1/src/refractor/plugins/normalize-parameters.ts
@@ -86,7 +86,7 @@ const inheritParametersToOperation = (
   // its meta, attributes, source map and style
   if (isArrayElement(originalParameters)) {
     if (!originalParameters.isMetaEmpty) {
-      mergedElement.meta = originalParameters.meta.cloneDeep();
+      mergedElement.meta = cloneDeep(originalParameters.meta);
     }
     if (!originalParameters.isAttributesEmpty) {
       mergedElement.attributes = cloneDeep(originalParameters.attributes);

--- a/packages/apidom-ns-openapi-3-1/src/refractor/plugins/normalize-parameters.ts
+++ b/packages/apidom-ns-openapi-3-1/src/refractor/plugins/normalize-parameters.ts
@@ -1,6 +1,13 @@
 import { uniqWith } from 'ramda';
 import { toValue } from '@speclynx/apidom-core';
-import { StringElement, isStringElement, isArrayElement } from '@speclynx/apidom-datamodel';
+import {
+  StringElement,
+  SourceMapElement,
+  StyleElement,
+  cloneDeep,
+  isStringElement,
+  isArrayElement,
+} from '@speclynx/apidom-datamodel';
 import { Path } from '@speclynx/apidom-traverse';
 import { OperationParametersElement } from '@speclynx/apidom-ns-openapi-3-0';
 
@@ -72,7 +79,23 @@ const inheritParametersToOperation = (
   // prefers the first item if two items compare equal based on the predicate
   const mergedParameters = uniqWith(parameterEquals, [...operationParams, ...pathItemParams]);
 
-  operationElement.parameters = new OperationParametersElement(mergedParameters);
+  const originalParameters = operationElement.parameters;
+  const mergedElement = new OperationParametersElement(mergedParameters);
+
+  // the merged container may replace an existing source container — carry over
+  // its meta, attributes, source map and style
+  if (isArrayElement(originalParameters)) {
+    if (!originalParameters.isMetaEmpty) {
+      mergedElement.meta = originalParameters.meta.cloneDeep();
+    }
+    if (!originalParameters.isAttributesEmpty) {
+      mergedElement.attributes = cloneDeep(originalParameters.attributes);
+    }
+    SourceMapElement.transfer(originalParameters, mergedElement);
+    StyleElement.transfer(originalParameters, mergedElement);
+  }
+
+  operationElement.parameters = mergedElement;
 };
 
 /**

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/container-preservation.ts
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/container-preservation.ts
@@ -42,10 +42,11 @@ describe('refractor', function () {
               plugins: [refractorPluginNormalizeParameters()],
             }) as OpenApi3_1Element;
 
-            const operationElement = openApiElement.paths?.get('/').get('get') as OperationElement;
+            const pathItemElement = openApiElement.paths?.get('/') as ObjectElement;
+            const operationElement = pathItemElement.get('get') as OperationElement;
             const mergedParameters = operationElement.parameters as ArrayElement;
 
-            assert.lengthOf(mergedParameters.content, 2);
+            assert.strictEqual(mergedParameters.length, 2);
             assert.deepEqual(mergedParameters.style, { yaml: { styleGroup: 'Flow' } });
             assert.strictEqual(mergedParameters.meta.get('custom-meta'), 'meta-value');
             assert.strictEqual(

--- a/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/container-preservation.ts
+++ b/packages/apidom-ns-openapi-3-1/test/refractor/plugins/normalize-parameters/container-preservation.ts
@@ -1,0 +1,66 @@
+import { assert } from 'chai';
+import { ArrayElement, ObjectElement } from '@speclynx/apidom-datamodel';
+import { toValue } from '@speclynx/apidom-core';
+
+import {
+  refractOpenApi3_1,
+  refractorPluginNormalizeParameters,
+  OpenApi3_1Element,
+  OperationElement,
+} from '../../../../src/index.ts';
+
+describe('refractor', function () {
+  context('plugins', function () {
+    context('normalize-parameters', function () {
+      context(
+        'given Operation parameters carrying meta, attributes, source map and style',
+        function () {
+          specify('should preserve them on the merged parameters container', function () {
+            const parameters = new ArrayElement([{ name: 'param2', in: 'query' }]);
+            parameters.style = { yaml: { styleGroup: 'Flow' } };
+            parameters.meta.set('custom-meta', 'meta-value');
+            parameters.attributes.set('custom-attribute', 'attribute-value');
+            parameters.startLine = 1;
+            parameters.startCharacter = 2;
+            parameters.startOffset = 3;
+            parameters.endLine = 4;
+            parameters.endCharacter = 5;
+            parameters.endOffset = 6;
+
+            const operation = new ObjectElement();
+            operation.set('parameters', parameters);
+            const pathItem = new ObjectElement({
+              parameters: [{ name: 'param1', in: 'query' }],
+            });
+            pathItem.set('get', operation);
+            const paths = new ObjectElement();
+            paths.set('/', pathItem);
+            const definition = new ObjectElement({ openapi: '3.1.0' });
+            definition.set('paths', paths);
+
+            const openApiElement = refractOpenApi3_1(definition, {
+              plugins: [refractorPluginNormalizeParameters()],
+            }) as OpenApi3_1Element;
+
+            const operationElement = openApiElement.paths?.get('/').get('get') as OperationElement;
+            const mergedParameters = operationElement.parameters as ArrayElement;
+
+            assert.lengthOf(mergedParameters.content, 2);
+            assert.deepEqual(mergedParameters.style, { yaml: { styleGroup: 'Flow' } });
+            assert.strictEqual(mergedParameters.meta.get('custom-meta'), 'meta-value');
+            assert.strictEqual(
+              toValue(mergedParameters.attributes.get('custom-attribute')),
+              'attribute-value',
+            );
+            assert.strictEqual(mergedParameters.startLine, 1);
+            assert.strictEqual(mergedParameters.startCharacter, 2);
+            assert.strictEqual(mergedParameters.startOffset, 3);
+            assert.strictEqual(mergedParameters.endLine, 4);
+            assert.strictEqual(mergedParameters.endCharacter, 5);
+            assert.strictEqual(mergedParameters.endOffset, 6);
+          });
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION
Style information was lost during refraction for array fields whose visitors use the `concat(cloneDeep(...))` pattern. A flow sequence like `tags: [payments, read]` parsed with `style: true` came out of refraction with `style: undefined` and serialized back as a block sequence:

```yaml
tags:
    - payments
    - read
```

## Root cause

`CollectionElement#concat` constructs a fresh element carrying only content — no meta, attributes, source maps, or style. Every other collection visitor (e.g. `ServersVisitor`, `ParametersVisitor`) finishes with `this.copyMetaAndAttributes(source, this.element)`, which transfers all four. Eight visitors skipped it:

- `ns-openapi-3-0`: operation `TagsVisitor` (reused by 3.1 via the shared bases)
- `ns-openapi-2`: `TagsVisitor` (operation), `ConsumesVisitor` and `ProducesVisitor` (root + operation), `SchemesVisitor` (root + operation)

## Fix

Add `this.copyMetaAndAttributes(arrayElement, this.element)` after the concat in all eight visitors. Since the concat result starts with empty meta, nothing is double-merged. Besides style, this also restores source maps and meta that were silently dropped for these fields.

## Audit of all other namespaces

A full sweep of every refractor visitor and plugin across `ns-asyncapi-2`, `ns-arazzo-1`, `ns-overlay-1`, `ns-json-schema-draft-4/6/7/2019-09/2020-12`, `ns-openapi-2/3-0/3-1` found no further visitor-level offenders: all base `Visitor.copyMetaAndAttributes` implementations include `StyleElement.transfer`, all `replace-empty-element` plugins transfer style, and the remaining rebuild sites either clone (clone copies style), delegate to `toRefractedElement`, or call `copyMetaAndAttributes` on the rebuilt container.

The sweep did surface one plugin-level gap, fixed here too: **`normalize-parameters`** (all three OpenAPI namespaces) replaced an Operation's *existing* `parameters` container with a fresh `OperationParametersElement` when merging PathItem parameters in, dropping the container's meta, attributes, source map, and style. The merged container now carries them over; synthesized containers for operations without their own parameters are unaffected.

## Tests

Regression test added in `ns-openapi-3-0` (`Operation` refractor: tags element carrying `style` survives refraction). Full suites pass: `ns-openapi-2` 180, `ns-openapi-3-0` 164, `ns-openapi-3-1` 210.

Together with #441, this makes a parse → mutate → serialize round-trip of a styled OpenAPI 3.1 YAML document byte-perfect for flow collections.

