### PR TITLE
feat(datamodel): support Metadata in cloneDeep and cloneShallow

### DIFF
--- a/packages/apidom-core/src/merge/deepmerge.ts
+++ b/packages/apidom-core/src/merge/deepmerge.ts
@@ -97,7 +97,7 @@ export type DeepMergeOptions = DeepMergeUserOptions & {
 };
 
 export const emptyElement = (element: ObjectElement | ArrayElement) => {
-  const meta = !element.isMetaEmpty ? element.meta.cloneDeep() : undefined;
+  const meta = !element.isMetaEmpty ? cloneDeep(element.meta) : undefined;
   const attributes = !element.isAttributesEmpty ? cloneDeep(element.attributes) : undefined;
 
   // @ts-ignore
@@ -126,7 +126,7 @@ const getMergeFunction = (keyElement: Element, options: DeepMergeOptions): DeepM
 
 const getMetaMergeFunction = (options: DeepMergeOptions): CustomMetaMerge => {
   if (typeof options.customMetaMerge !== 'function') {
-    return (targetMeta) => targetMeta.cloneDeep();
+    return (targetMeta) => cloneDeep(targetMeta);
   }
   return options.customMetaMerge;
 };
@@ -240,9 +240,9 @@ const deepmerge = (
       sourceElement.meta,
     );
   } else if (!targetElement.isMetaEmpty) {
-    mergedElement.meta = targetElement.meta.cloneDeep();
+    mergedElement.meta = cloneDeep(targetElement.meta);
   } else if (!sourceElement.isMetaEmpty) {
-    mergedElement.meta = sourceElement.meta.cloneDeep();
+    mergedElement.meta = cloneDeep(sourceElement.meta);
   }
   if (!targetElement.isAttributesEmpty && !sourceElement.isAttributesEmpty) {
     mergedElement.attributes = getAttributesMergeFunction(mergedOptions)(

--- a/packages/apidom-datamodel/src/clone/index.ts
+++ b/packages/apidom-datamodel/src/clone/index.ts
@@ -2,6 +2,7 @@ import { clone } from 'ramda';
 
 import ObjectSlice from '../ObjectSlice.ts';
 import KeyValuePair from '../KeyValuePair.ts';
+import Metadata from '../Metadata.ts';
 import Element from '../primitives/Element.ts';
 import MemberElement from '../primitives/MemberElement.ts';
 import { isElement, hasElementSourceMap, hasElementStyle } from '../predicates/index.ts';
@@ -12,7 +13,7 @@ import ShallowCloneError from './errors/ShallowCloneError.ts';
 /**
  * @public
  */
-export type FinalCloneTypes = KeyValuePair | ObjectSlice;
+export type FinalCloneTypes = KeyValuePair | ObjectSlice | Metadata;
 
 /**
  * @public
@@ -80,7 +81,7 @@ const cloneDeepObjectSlice = (slice: ObjectSlice, options: DeepCloneOptions): Ob
 };
 
 /**
- * Creates a deep clone of an ApiDOM Element, KeyValuePair, or ObjectSlice.
+ * Creates a deep clone of an ApiDOM Element, KeyValuePair, ObjectSlice, or Metadata.
  * Handles cycles by memoizing visited objects.
  * @public
  */
@@ -94,6 +95,10 @@ export const cloneDeep = <T extends Element | FinalCloneTypes>(
 
   if (value instanceof ObjectSlice) {
     return cloneDeepObjectSlice(value, options) as T;
+  }
+
+  if (value instanceof Metadata) {
+    return value.cloneDeep() as T;
   }
 
   if (isElement(value)) {
@@ -129,7 +134,7 @@ const cloneShallowElement = <T extends Element>(element: T): T => {
   copy.element = element.element;
 
   if (!element.isMetaEmpty) {
-    copy.meta = element.meta.cloneDeep();
+    copy.meta = cloneDeep(element.meta);
   }
 
   if (!element.isAttributesEmpty) {
@@ -159,7 +164,7 @@ const cloneShallowElement = <T extends Element>(element: T): T => {
 };
 
 /**
- * Creates a shallow clone of an ApiDOM Element, KeyValuePair, or ObjectSlice.
+ * Creates a shallow clone of an ApiDOM Element, KeyValuePair, ObjectSlice, or Metadata.
  * The element itself is cloned, but content references are shared.
  * Meta and attributes are deep cloned to preserve semantic information.
  * @public
@@ -171,6 +176,10 @@ export const cloneShallow = <T extends Element | FinalCloneTypes>(value: T): T =
 
   if (value instanceof ObjectSlice) {
     return cloneShallowObjectSlice(value) as T;
+  }
+
+  if (value instanceof Metadata) {
+    return value.cloneShallow() as T;
   }
 
   if (isElement(value)) {

--- a/packages/apidom-datamodel/test/clone.ts
+++ b/packages/apidom-datamodel/test/clone.ts
@@ -1,0 +1,79 @@
+import { assert } from 'chai';
+
+import { Metadata, StringElement, cloneDeep, cloneShallow } from '../src/index.ts';
+
+describe('clone', function () {
+  context('given Metadata', function () {
+    describe('cloneDeep', function () {
+      specify('should create a new Metadata instance', function () {
+        const meta = new Metadata();
+        meta.set('id', 'test');
+        const clone = cloneDeep(meta);
+        assert.notStrictEqual(clone, meta);
+        assert.instanceOf(clone, Metadata);
+      });
+
+      specify('should deep clone Element values', function () {
+        const el = new StringElement('hello');
+        const meta = new Metadata();
+        meta.set('custom', el);
+        const clone = cloneDeep(meta);
+        const clonedEl = clone.get('custom') as StringElement;
+        assert.notStrictEqual(clonedEl, el);
+        assert.strictEqual(clonedEl.toValue(), 'hello');
+      });
+
+      specify('should deep clone array values', function () {
+        const classes = ['a', 'b'];
+        const meta = new Metadata();
+        meta.set('classes', classes);
+        const clone = cloneDeep(meta);
+        assert.deepEqual(clone.get('classes'), ['a', 'b']);
+        assert.notStrictEqual(clone.get('classes'), classes);
+      });
+    });
+
+    describe('cloneDeep.safe', function () {
+      specify('should clone instead of returning the same reference', function () {
+        const meta = new Metadata();
+        meta.set('id', 'test');
+        const clone = cloneDeep.safe(meta);
+        assert.notStrictEqual(clone, meta);
+        assert.instanceOf(clone, Metadata);
+        assert.strictEqual(clone.get('id'), 'test');
+      });
+    });
+
+    describe('cloneShallow', function () {
+      specify('should create a new Metadata instance', function () {
+        const meta = new Metadata();
+        meta.set('id', 'test');
+        const clone = cloneShallow(meta);
+        assert.notStrictEqual(clone, meta);
+        assert.instanceOf(clone, Metadata);
+      });
+
+      specify('should share references', function () {
+        const el = new StringElement('hello');
+        const classes = ['a', 'b'];
+        const meta = new Metadata();
+        meta.set('custom', el);
+        meta.set('classes', classes);
+        const clone = cloneShallow(meta);
+        assert.strictEqual(clone.get('custom'), el);
+        assert.strictEqual(clone.get('classes'), classes);
+      });
+    });
+
+    describe('cloneShallow.safe', function () {
+      specify('should clone instead of returning the same reference', function () {
+        const meta = new Metadata();
+        meta.set('id', 'test');
+        const clone = cloneShallow.safe(meta);
+        assert.notStrictEqual(clone, meta);
+        assert.instanceOf(clone, Metadata);
+        assert.strictEqual(clone.get('id'), 'test');
+      });
+    });
+  });
+});

--- a/packages/apidom-ns-arazzo-1/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-arazzo-1/src/refractor/plugins/replace-empty-element.ts
@@ -106,7 +106,7 @@ const plugin = () => () => ({
 
       const replacement = elementFactory(
         undefined,
-        element.isMetaEmpty ? undefined : element.meta.cloneDeep(),
+        element.isMetaEmpty ? undefined : cloneDeep(element.meta),
         element.isAttributesEmpty ? undefined : cloneDeep(element.attributes),
       );
       SourceMapElement.transfer(element, replacement);

--- a/packages/apidom-ns-arazzo-1/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-arazzo-1/src/refractor/visitors/Visitor.ts
@@ -32,7 +32,7 @@ class Visitor {
     if (!from.isMetaEmpty && !to.isMetaEmpty) {
       to.meta = to.meta.merge(from.meta);
     } else if (!from.isMetaEmpty) {
-      to.meta = from.meta.cloneDeep();
+      to.meta = cloneDeep(from.meta);
     }
     if (!from.isAttributesEmpty && !to.isAttributesEmpty) {
       to.attributes = deepmerge(to.attributes, from.attributes) as ObjectElement;

--- a/packages/apidom-ns-asyncapi-2/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-asyncapi-2/src/refractor/plugins/replace-empty-element.ts
@@ -1074,7 +1074,7 @@ const plugin = () => () => ({
       const replacement = elementFactory.call(
         { context },
         undefined,
-        element.isMetaEmpty ? undefined : element.meta.cloneDeep(),
+        element.isMetaEmpty ? undefined : cloneDeep(element.meta),
         element.isAttributesEmpty ? undefined : cloneDeep(element.attributes),
       );
 

--- a/packages/apidom-ns-asyncapi-2/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-asyncapi-2/src/refractor/visitors/Visitor.ts
@@ -32,7 +32,7 @@ class Visitor {
     if (!from.isMetaEmpty && !to.isMetaEmpty) {
       to.meta = to.meta.merge(from.meta);
     } else if (!from.isMetaEmpty) {
-      to.meta = from.meta.cloneDeep();
+      to.meta = cloneDeep(from.meta);
     }
     if (!from.isAttributesEmpty && !to.isAttributesEmpty) {
       to.attributes = deepmerge(to.attributes, from.attributes) as ObjectElement;

--- a/packages/apidom-ns-json-schema-2019-09/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-json-schema-2019-09/src/refractor/plugins/replace-empty-element.ts
@@ -274,7 +274,7 @@ const plugin = () => () => {
         const replacement = elementFactory.call(
           { context },
           undefined,
-          element.isMetaEmpty ? undefined : element.meta.cloneDeep(),
+          element.isMetaEmpty ? undefined : cloneDeep(element.meta),
           element.isAttributesEmpty ? undefined : cloneDeep(element.attributes),
         );
 

--- a/packages/apidom-ns-json-schema-2020-12/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-json-schema-2020-12/src/refractor/plugins/replace-empty-element.ts
@@ -281,7 +281,7 @@ const plugin = () => () => {
         const replacement = elementFactory.call(
           { context },
           undefined,
-          element.isMetaEmpty ? undefined : element.meta.cloneDeep(),
+          element.isMetaEmpty ? undefined : cloneDeep(element.meta),
           element.isAttributesEmpty ? undefined : cloneDeep(element.attributes),
         );
 

--- a/packages/apidom-ns-json-schema-draft-4/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-json-schema-draft-4/src/refractor/plugins/replace-empty-element.ts
@@ -218,7 +218,7 @@ const plugin = () => () => ({
       const replacement = elementFactory.call(
         { context },
         undefined,
-        element.isMetaEmpty ? undefined : element.meta.cloneDeep(),
+        element.isMetaEmpty ? undefined : cloneDeep(element.meta),
         element.isAttributesEmpty ? undefined : cloneDeep(element.attributes),
       );
 

--- a/packages/apidom-ns-json-schema-draft-4/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-json-schema-draft-4/src/refractor/visitors/Visitor.ts
@@ -32,7 +32,7 @@ class Visitor {
     if (!from.isMetaEmpty && !to.isMetaEmpty) {
       to.meta = to.meta.merge(from.meta);
     } else if (!from.isMetaEmpty) {
-      to.meta = from.meta.cloneDeep();
+      to.meta = cloneDeep(from.meta);
     }
 
     if (!from.isAttributesEmpty && !to.isAttributesEmpty) {

--- a/packages/apidom-ns-json-schema-draft-6/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-json-schema-draft-6/src/refractor/plugins/replace-empty-element.ts
@@ -229,7 +229,7 @@ const plugin = () => () => ({
       const replacement = elementFactory.call(
         { context },
         undefined,
-        element.isMetaEmpty ? undefined : element.meta.cloneDeep(),
+        element.isMetaEmpty ? undefined : cloneDeep(element.meta),
         element.isAttributesEmpty ? undefined : cloneDeep(element.attributes),
       );
 

--- a/packages/apidom-ns-json-schema-draft-7/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-json-schema-draft-7/src/refractor/plugins/replace-empty-element.ts
@@ -246,7 +246,7 @@ const plugin = () => () => ({
       const replacement = elementFactory.call(
         { context },
         undefined,
-        element.isMetaEmpty ? undefined : element.meta.cloneDeep(),
+        element.isMetaEmpty ? undefined : cloneDeep(element.meta),
         element.isAttributesEmpty ? undefined : cloneDeep(element.attributes),
       );
 

--- a/packages/apidom-ns-openapi-2/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/plugins/replace-empty-element.ts
@@ -375,7 +375,7 @@ const plugin = () => () => ({
       const replacement = elementFactory.call(
         { context },
         undefined,
-        element.isMetaEmpty ? undefined : element.meta.cloneDeep(),
+        element.isMetaEmpty ? undefined : cloneDeep(element.meta),
         element.isAttributesEmpty ? undefined : cloneDeep(element.attributes),
       );
 

--- a/packages/apidom-ns-openapi-2/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-openapi-2/src/refractor/visitors/Visitor.ts
@@ -32,7 +32,7 @@ class Visitor {
     if (!from.isMetaEmpty && !to.isMetaEmpty) {
       to.meta = to.meta.merge(from.meta);
     } else if (!from.isMetaEmpty) {
-      to.meta = from.meta.cloneDeep();
+      to.meta = cloneDeep(from.meta);
     }
     if (!from.isAttributesEmpty && !to.isAttributesEmpty) {
       to.attributes = deepmerge(to.attributes, from.attributes) as ObjectElement;

--- a/packages/apidom-ns-openapi-3-0/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-openapi-3-0/src/refractor/plugins/replace-empty-element.ts
@@ -643,7 +643,7 @@ const plugin = () => () => ({
       const newElement = elementFactory.call(
         { context },
         undefined,
-        element.isMetaEmpty ? undefined : element.meta.cloneDeep(),
+        element.isMetaEmpty ? undefined : cloneDeep(element.meta),
         element.isAttributesEmpty ? undefined : cloneDeep(element.attributes),
       );
       SourceMapElement.transfer(element, newElement);

--- a/packages/apidom-ns-openapi-3-0/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-openapi-3-0/src/refractor/visitors/Visitor.ts
@@ -32,7 +32,7 @@ class Visitor {
     if (!from.isMetaEmpty && !to.isMetaEmpty) {
       to.meta = to.meta.merge(from.meta);
     } else if (!from.isMetaEmpty) {
-      to.meta = from.meta.cloneDeep();
+      to.meta = cloneDeep(from.meta);
     }
     if (!from.isAttributesEmpty && !to.isAttributesEmpty) {
       to.attributes = deepmerge(to.attributes, from.attributes) as ObjectElement;

--- a/packages/apidom-ns-openapi-3-1/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-openapi-3-1/src/refractor/plugins/replace-empty-element.ts
@@ -712,7 +712,7 @@ const plugin = () => () => {
         const newElement = elementFactory.call(
           { context },
           undefined,
-          element.isMetaEmpty ? undefined : element.meta.cloneDeep(),
+          element.isMetaEmpty ? undefined : cloneDeep(element.meta),
           element.isAttributesEmpty ? undefined : cloneDeep(element.attributes),
         );
         SourceMapElement.transfer(element, newElement);

--- a/packages/apidom-ns-overlay-1/src/refractor/plugins/replace-empty-element.ts
+++ b/packages/apidom-ns-overlay-1/src/refractor/plugins/replace-empty-element.ts
@@ -114,7 +114,7 @@ const plugin = () => () => ({
 
       const replacement = elementFactory(
         undefined,
-        element.isMetaEmpty ? undefined : element.meta.cloneDeep(),
+        element.isMetaEmpty ? undefined : cloneDeep(element.meta),
         element.isAttributesEmpty ? undefined : cloneDeep(element.attributes),
       );
       SourceMapElement.transfer(element, replacement);

--- a/packages/apidom-ns-overlay-1/src/refractor/visitors/Visitor.ts
+++ b/packages/apidom-ns-overlay-1/src/refractor/visitors/Visitor.ts
@@ -32,7 +32,7 @@ class Visitor {
     if (!from.isMetaEmpty && !to.isMetaEmpty) {
       to.meta = to.meta.merge(from.meta);
     } else if (!from.isMetaEmpty) {
-      to.meta = from.meta.cloneDeep();
+      to.meta = cloneDeep(from.meta);
     }
     if (!from.isAttributesEmpty && !to.isAttributesEmpty) {
       to.attributes = deepmerge(to.attributes, from.attributes) as ObjectElement;


### PR DESCRIPTION
## Motivation

`Element.meta` is a `Metadata` instance while `Element.attributes` is an `ObjectElement`, so cloning them required two different mechanisms: `element.meta.cloneDeep()` (method) vs `cloneDeep(element.attributes)` (function). Worse, passing a `Metadata` to the generic clone functions threw `DeepCloneError`, and `cloneDeep.safe(metadata)` / `cloneShallow.safe(metadata)` silently returned the **same reference** — defeating the purpose of cloning.

## Changes

- `cloneDeep()` and `cloneShallow()` now recognize `Metadata` instances and delegate to `Metadata#cloneDeep()` / `Metadata#cloneShallow()`. The clone logic stays in the `Metadata` methods, which hold the injected `cloneDeepElement` (the registration indirection that avoids a circular dependency).
- `Metadata` added to the public `FinalCloneTypes` union.
- All production call sites of `element.meta.cloneDeep()` across the monorepo (apidom-core `deepmerge`, ns-* refractor `Visitor`s and `replace-empty-element` plugins — 21 sites in 18 files) migrated to the generic `cloneDeep(element.meta)`, symmetric with `cloneDeep(element.attributes)`. The `Metadata` method unit tests remain, as the methods are still the implementation.
- New tests covering the `Metadata` dispatch paths, including `cloneDeep.safe` / `cloneShallow.safe` now actually cloning.

No behavioral change for existing valid inputs — only previously-throwing/no-op `Metadata` inputs gain behavior.

Note: `Metadata.cloneDeep()` takes no `visited` map, so cycle memoization is not shared with an enclosing element clone. This matches the existing behavior for `attributes` and is intentionally left as is.
