### PR TITLE
fix(ns-openapi-3-0): correct sideEffects path to refractor/inspect

### DIFF
--- a/packages/apidom-ns-openapi-3-0/package.json
+++ b/packages/apidom-ns-openapi-3-0/package.json
@@ -22,8 +22,8 @@
   },
   "type": "module",
   "sideEffects": [
-    "./src/refractor/registration.mjs",
-    "./src/refractor/registration.cjs"
+    "./src/refractor/inspect.mjs",
+    "./src/refractor/inspect.cjs"
   ],
   "unpkg": "./dist/apidom-ns-openapi-3-0.browser.min.js",
   "main": "./src/index.cjs",


### PR DESCRIPTION
## Problem

`packages/apidom-ns-openapi-3-0/package.json` declares its side-effectful module as `./src/refractor/registration.mjs` / `.cjs`. Those files were renamed to `inspect.mjs` / `.cjs` in cfdbbfc2. That commit migrated `apidom-ns-openapi-3-1`'s `sideEffects` correctly and touched `apidom-ns-openapi-3-0`'s `package.json` only for unrelated dependency/script edits, so the stale paths survived. It is the only one of the ten namespace packages still pointing at a file that does not exist.

## Why it breaks bundled consumers

`src/index.ts` re-exports the element classes *from* `./refractor/inspect.ts`, and `inspect.ts` installs the static `fixedFields` getters via `Object.defineProperty` before re-exporting them from `../elements/*.ts`.

Because the stale `sideEffects` list leaves `inspect.mjs` marked side-effect-free, this is not statement-level dead-code elimination — it is webpack's re-export skipping. The bundler rewires the import straight to `src/elements/Components.mjs` and never evaluates `inspect.mjs`, so none of the 27 registrations run.

Downstream, `apidom-reference/src/bundle/strategies/openapi-3-0/visitor.ts:67` builds its Components field maps at module scope:

```js
const cf = fixedFields(ComponentsElement, { indexed: true });
const componentFieldByReferencedElement = { schema: cf.schemas.name, … };
```

With the registrations elided, `fixedFields` returns `[]`, the indexed object is `{}`, and `cf.schemas.name` throws a `TypeError` while the module is still loading — so a consuming app fails to start rather than failing at use.

The published UMD bundle is affected too: `dist/apidom-ns-openapi-3-0.browser.js` contains zero `defineProperty(…, 'fixedFields')` calls, while `apidom-ns-openapi-3-1`'s contains all of its.

## Fix

Point `sideEffects` at the current filenames, matching every other namespace package.

## Verification

Isolated webpack build (production mode) against the local workspace, importing `ComponentsElement` from the package entry:

```
before:  static fixedFields: undefined   indexed keys: (EMPTY)   -> cf.schemas.name TypeError
after:   static fixedFields: len 9       indexed keys: schemas,responses,parameters,examples,
                                                       requestBodies,headers,securitySchemes,
                                                       links,callbacks
         cf.schemas.name -> "schemas"
```

Also audited every `sideEffects` entry across all packages against its source file — this was the only stale one.

## Notes for reviewers

`apidom-ns-openapi-3-0` currently has 21 failing tests on `main` (refractor plugins: parameter normalization, security-scheme scopes, replace-empty-element). They fail identically with and without this change (144 passing / 21 failing both ways), so they are pre-existing and out of scope here.

Two hardening ideas were considered alongside this and deliberately not included:

- Making `fixedFields` throw when a class has no registered metadata. "Not registered" and "genuinely has no fixed fields" are the same state and cannot be distinguished. `PathsElement`, `CallbackElement`, `SecurityRequirementElement` and `OpenapiElement` are patterned-fields objects that correctly return `[]` under a fully working ESM load, and `packages/apidom-core/test/fields/fixed-fields.ts:7-22` contracts that behaviour on a public API.
- Computing `cf` lazily in `visitor.ts`. That relocates the failure rather than removing it: with the packaging bug present it would still resolve to `{}` and throw on the first `bundle()` call, which is harder to diagnose than a load-time crash. There is no load-order hazard once packaging is correct, since ESM guarantees the package entry has fully evaluated before the importing module body runs and there is no cycle.

A CI check asserting each `sideEffects` path resolves to a real source file would have caught this at the rename; happy to open a follow-up issue for that if wanted.

No existing issue matched a search for `sideEffects` or tree-shaking, so nothing is linked.